### PR TITLE
Change Log:

### DIFF
--- a/eegplugin_eyesort.m
+++ b/eegplugin_eyesort.m
@@ -119,6 +119,9 @@ function currvers = eegplugin_eyesort(fig, ~, ~)
             uimenu(submenu, 'label', 'Generate BINLISTER BDF File', 'separator', 'on', ...
                 'callback', @(src,event) try_callback(@pop_generate_bdf, src, event));
             
+            uimenu(submenu, 'label', 'Modify Event Marker Format', 'separator', 'off', ...
+                'callback', @(src,event) try_callback(@pop_convert_event_codes, src, event));
+            
             uimenu(submenu, 'label', 'Help', 'separator', 'on', ...
                    'callback', @(src,event) try_callback(@help_button, src, event));
 

--- a/eyesort_default_values.m
+++ b/eyesort_default_values.m
@@ -1,2 +1,2 @@
 % Current EyeSort version
-eyesortver = '0.5.0';
+eyesortver = '0.5.1';

--- a/functions/convert_config_to_params.m
+++ b/functions/convert_config_to_params.m
@@ -118,4 +118,10 @@ end
 label_params{end+1} = 'saccadeOutOptions';
 label_params{end+1} = saccadeOutOptions;
 
+% Event format
+if isfield(config, 'eventFormat') && ~isempty(config.eventFormat)
+    label_params{end+1} = 'eventFormat';
+    label_params{end+1} = config.eventFormat;
+end
+
 end 

--- a/functions/convert_event_codes.m
+++ b/functions/convert_event_codes.m
@@ -1,0 +1,157 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+% Author: Brandon Snyder
+
+function EEG = convert_event_codes(EEG, eventFormat)
+% CONVERT_EVENT_CODES - Convert EEG.event.type to a different format
+%
+% Rewrites EEG.event.type for all labeled events (those with a non-empty
+% eyesort_full_code) using one of the supported format options. The
+% canonical CCRRLL code in eyesort_full_code is never modified.
+%
+% Usage:
+%   EEG = convert_event_codes(EEG, eventFormat)
+%
+% Inputs:
+%   EEG         - EEGLAB dataset with labeled events
+%   eventFormat - One of:
+%       'numeric'          - 6-digit CCRRLL code (ERPLAB compatible)
+%       'description'      - Condition + label description
+%       'description_word' - Condition + label + fixated word
+%       'region_content'   - Full text of the fixated region
+%       'original'         - Restore original pre-EyeSort event codes
+%
+% Outputs:
+%   EEG - Dataset with updated EEG.event.type values
+
+if nargin < 2
+    error('convert_event_codes requires an eventFormat argument.');
+end
+
+validFormats = {'numeric', 'description', 'description_word', 'region_content', 'original'};
+if ~ismember(eventFormat, validFormats)
+    error('Invalid eventFormat ''%s''. Must be one of: %s', eventFormat, strjoin(validFormats, ', '));
+end
+
+if ~isfield(EEG, 'event') || isempty(EEG.event)
+    warning('EEG dataset has no events. Nothing to convert.');
+    return;
+end
+
+if ~isfield(EEG.event, 'eyesort_full_code')
+    warning('No eyesort_full_code field found. Dataset may not have been labeled yet.');
+    return;
+end
+
+convertedCount = 0;
+
+for i = 1:length(EEG.event)
+    evt = EEG.event(i);
+
+    if ~ischar(evt.eyesort_full_code) || isempty(evt.eyesort_full_code)
+        continue;
+    end
+
+    switch eventFormat
+        case 'numeric'
+            EEG.event(i).type = evt.eyesort_full_code;
+
+        case 'description'
+            descType = '';
+            if isfield(evt, 'bdf_full_description') && ~isempty(evt.bdf_full_description)
+                descType = evt.bdf_full_description;
+            end
+            if ~isempty(descType)
+                EEG.event(i).type = descType;
+            else
+                EEG.event(i).type = evt.eyesort_full_code;
+            end
+
+        case 'description_word'
+            descType = '';
+            if isfield(evt, 'bdf_full_description') && ~isempty(evt.bdf_full_description)
+                descType = evt.bdf_full_description;
+            end
+            wordText = resolve_word_text(evt);
+            if ~isempty(descType) && ~isempty(wordText)
+                EEG.event(i).type = [descType ' ' wordText];
+            elseif ~isempty(descType)
+                EEG.event(i).type = descType;
+            else
+                EEG.event(i).type = evt.eyesort_full_code;
+            end
+
+        case 'region_content'
+            regionText = resolve_region_text(evt);
+            if ~isempty(regionText)
+                EEG.event(i).type = regionText;
+            else
+                EEG.event(i).type = evt.eyesort_full_code;
+            end
+
+        case 'original'
+            if isfield(evt, 'original_type') && ~isempty(evt.original_type)
+                EEG.event(i).type = evt.original_type;
+            end
+    end
+
+    convertedCount = convertedCount + 1;
+end
+
+EEG.eyesort_event_format = eventFormat;
+fprintf('Converted %d event(s) to ''%s'' format.\n', convertedCount, eventFormat);
+
+end
+
+%% Helper: resolve the actual word string from current_word or current_word_text
+function wordText = resolve_word_text(evt)
+    wordText = '';
+    if isfield(evt, 'current_word_text') && ischar(evt.current_word_text) && ~isempty(evt.current_word_text)
+        wordText = evt.current_word_text;
+        return;
+    end
+    if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+        try
+            [regionNum, wordNum] = parse_word_region(evt.current_word);
+            wordsField = sprintf('region%d_words', regionNum);
+            if isfield(evt, wordsField) && ~isempty(evt.(wordsField))
+                words = evt.(wordsField);
+                if iscell(words) && wordNum <= length(words)
+                    wordText = strtrim(words{wordNum});
+                end
+            end
+        catch
+        end
+    end
+end
+
+%% Helper: resolve the full text of the fixated region
+function regionText = resolve_region_text(evt)
+    regionText = '';
+    if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+        try
+            [regionNum, ~] = parse_word_region(evt.current_word);
+            textField = sprintf('region%d_text', regionNum);
+            if isfield(evt, textField) && ischar(evt.(textField)) && ~isempty(evt.(textField))
+                regionText = strtrim(evt.(textField));
+            end
+        catch
+        end
+    end
+end

--- a/functions/label_datasets_core.m
+++ b/functions/label_datasets_core.m
@@ -133,6 +133,7 @@ if ~isempty(varargin) && ischar(varargin{1}) && (endsWith(varargin{1}, '.m') || 
     labelDescription = get_config_value(config, 'labelDescription', '');
     conflictResolution = get_config_value(config, 'conflictResolution', 'ask');
     showRegionMap = get_config_value(config, 'showRegionMap', true);
+    eventFormat = get_config_value(config, 'eventFormat', 'numeric');
     
 else
     % Individual parameters method (original)
@@ -151,6 +152,7 @@ else
     addParameter(p, 'labelDescription', '', @ischar);
     addParameter(p, 'conflictResolution', 'ask', @ischar);
     addParameter(p, 'showRegionMap', true, @islogical);
+    addParameter(p, 'eventFormat', 'numeric', @ischar);
     
     parse(p, EEG, varargin{:});
     
@@ -168,6 +170,7 @@ else
     labelDescription = p.Results.labelDescription;
     conflictResolution = p.Results.conflictResolution;
     showRegionMap = p.Results.showRegionMap;
+    eventFormat = p.Results.eventFormat;
 end
 
 % Validate input EEG structure
@@ -239,8 +242,11 @@ try
                                             passOptions, prevRegions, nextRegions, ...
                                             fixationOptions, saccadeInOptions, saccadeOutOptions, labelCount, ...
                                             fixationType, fixationXField, saccadeType, ...
-                                            saccadeStartXField, saccadeEndXField, labelDescription, rtl, conflictResolution, showRegionMap);
+                                            saccadeStartXField, saccadeEndXField, labelDescription, rtl, conflictResolution, showRegionMap, eventFormat);
     
+    % Store the event format used for labeling
+    labeledEEG.eyesort_event_format = eventFormat;
+
     % Update label count and descriptions
     labeledEEG.eyesort_label_count = labelCount;
     if ~isfield(labeledEEG, 'eyesort_label_descriptions')
@@ -292,7 +298,7 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                                                 fixationOptions, saccadeInOptions, ...
                                                 saccadeOutOptions, labelCount, ...
                                                 fixationType, fixationXField, saccadeType, ...
-                                                saccadeStartXField, saccadeEndXField, labelDescription, rtl, conflictResolution, showRegionMap)
+                                                saccadeStartXField, saccadeEndXField, labelDescription, rtl, conflictResolution, showRegionMap, eventFormat)
     % Optimized internal labeling implementation with O(n) complexity
     
     % Initialize conflict resolution output
@@ -889,15 +895,13 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
             continue; % Skip this event instead of overwriting
         end
         
-        % Update the event type and related fields
-        labeledEEG.event(mm).type = newType;
+        % Always store the canonical CCRRLL code and sub-codes
         labeledEEG.event(mm).eyesort_condition_code = condStr;
         labeledEEG.event(mm).eyesort_region_code = regionStr;
         labeledEEG.event(mm).eyesort_label_code = labelStr;
         labeledEEG.event(mm).eyesort_full_code = newType;
         
         % Initialize BDF description fields for ALL events (only once, after eyesort fields)
-        % Only initialize if fields don't exist to preserve existing descriptions
         if ~bdf_fields_initialized
             if ~isfield(labeledEEG.event, 'bdf_condition_description')
                 fprintf('Initializing BDF description fields for all events...\n');
@@ -905,46 +909,56 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                 [labeledEEG.event.bdf_label_description] = deal('');
                 [labeledEEG.event.bdf_full_description] = deal('');
             end
+            if ~isfield(labeledEEG.event, 'current_word_text')
+                [labeledEEG.event.current_word_text] = deal('');
+            end
             bdf_fields_initialized = true;
         end
         
-        % Add BDF description columns directly (only to labeled events to minimize 7.3 risk)
-        if ~isempty(labelDescription)
-            % Get condition description string from lookup
-            conditionDesc = '';
-            if isfield(labeledEEG, 'eyesort_condition_descriptions') && ...
-               isfield(labeledEEG, 'eyesort_condition_lookup') && ...
-               conditionNumbers(mm) > 0 && itemNumbers(mm) > 0
-                key = sprintf('%d_%d', conditionNumbers(mm), itemNumbers(mm));
-                if isKey(validKeyCache, key)
-                    validKey = validKeyCache(key);
-                else
-                    validKey = matlab.lang.makeValidName(['k_' key]);
-                    validKeyCache(key) = validKey;
-                end
-                condStruct = labeledEEG.eyesort_condition_descriptions;
-                if isfield(condStruct, validKey)
-                    conditionNum = condStruct.(validKey); % This is numeric
-                    % Convert back to string using lookup
-                    if isKey(labeledEEG.eyesort_condition_lookup, num2str(conditionNum))
-                        conditionDesc = labeledEEG.eyesort_condition_lookup(num2str(conditionNum));
+        % Resolve the actual word text from the positional current_word index
+        wordText = '';
+        if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+            try
+                [regionNum, wordNum] = parse_word_region(evt.current_word);
+                wordsField = sprintf('region%d_words', regionNum);
+                if isfield(evt, wordsField) && ~isempty(evt.(wordsField))
+                    words = evt.(wordsField);
+                    if iscell(words) && wordNum <= length(words)
+                        wordText = strtrim(words{wordNum});
                     end
                 end
+            catch
             end
-            
-            % Store actual strings in dataset (only on labeled events)
-            % Handle empty strings properly to avoid concatenation issues
-            if isempty(conditionDesc)
-                conditionDesc = '';
+        end
+        labeledEEG.event(mm).current_word_text = wordText;
+        
+        % Resolve condition description (needed for BDF fields and text formats)
+        conditionDesc = '';
+        if isfield(labeledEEG, 'eyesort_condition_descriptions') && ...
+           isfield(labeledEEG, 'eyesort_condition_lookup') && ...
+           conditionNumbers(mm) > 0 && itemNumbers(mm) > 0
+            key = sprintf('%d_%d', conditionNumbers(mm), itemNumbers(mm));
+            if isKey(validKeyCache, key)
+                validKey = validKeyCache(key);
+            else
+                validKey = matlab.lang.makeValidName(['k_' key]);
+                validKeyCache(key) = validKey;
             end
-            if isempty(labelDescription)
-                labelDescription = '';
+            condStruct = labeledEEG.eyesort_condition_descriptions;
+            if isfield(condStruct, validKey)
+                conditionNum = condStruct.(validKey);
+                if isKey(labeledEEG.eyesort_condition_lookup, num2str(conditionNum))
+                    conditionDesc = labeledEEG.eyesort_condition_lookup(num2str(conditionNum));
+                end
             end
-            
+        end
+        if isempty(conditionDesc), conditionDesc = ''; end
+        
+        % Store BDF description fields (only when labelDescription is provided)
+        if ~isempty(labelDescription)
             labeledEEG.event(mm).bdf_condition_description = char(conditionDesc);
             labeledEEG.event(mm).bdf_label_description = char(labelDescription);
             
-            % Safe concatenation that handles empty strings
             if isempty(conditionDesc) && isempty(labelDescription)
                 labeledEEG.event(mm).bdf_full_description = '';
             elseif isempty(conditionDesc)
@@ -954,6 +968,49 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
             else
                 labeledEEG.event(mm).bdf_full_description = [char(conditionDesc) ' ' char(labelDescription)];
             end
+        end
+        
+        % Set EEG.event.type based on the chosen eventFormat
+        switch eventFormat
+            case 'numeric'
+                labeledEEG.event(mm).type = newType;
+            case 'description'
+                descType = build_description_type(conditionDesc, labelDescription);
+                if isempty(descType)
+                    labeledEEG.event(mm).type = newType;
+                else
+                    labeledEEG.event(mm).type = descType;
+                end
+            case 'description_word'
+                descType = build_description_type(conditionDesc, labelDescription);
+                if isempty(descType)
+                    labeledEEG.event(mm).type = newType;
+                elseif ~isempty(wordText)
+                    labeledEEG.event(mm).type = [descType ' ' wordText];
+                else
+                    labeledEEG.event(mm).type = descType;
+                end
+            case 'region_content'
+                regionText = '';
+                if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+                    try
+                        [regionNum, ~] = parse_word_region(evt.current_word);
+                        textField = sprintf('region%d_text', regionNum);
+                        if isfield(evt, textField) && ischar(evt.(textField)) && ~isempty(evt.(textField))
+                            regionText = strtrim(evt.(textField));
+                        end
+                    catch
+                    end
+                end
+                if ~isempty(regionText)
+                    labeledEEG.event(mm).type = regionText;
+                else
+                    labeledEEG.event(mm).type = newType;
+                end
+            case 'original'
+                % Do not overwrite type; leave it as original_type
+            otherwise
+                labeledEEG.event(mm).type = newType;
         end
     end
     
@@ -994,28 +1051,86 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                 evt_idx = conflictingEvents{i}.event_index;
                 new_code = conflictingEvents{i}.new_code;
                 
-                % Update the event with new code
-                labeledEEG.event(evt_idx).type = new_code;
+                % Always update the canonical CCRRLL code
                 labeledEEG.event(evt_idx).eyesort_full_code = new_code;
                 labeledEEG.event(evt_idx).eyesort_condition_code = new_code(1:2);
                 labeledEEG.event(evt_idx).eyesort_region_code = new_code(3:4);
                 labeledEEG.event(evt_idx).eyesort_label_code = new_code(5:6);
                 
                 % Update BDF descriptions with current label description
+                conditionDesc = '';
                 if ~isempty(labelDescription)
-                    % Get existing condition description
-                    conditionDesc = '';
                     if isfield(labeledEEG.event(evt_idx), 'bdf_condition_description')
                         conditionDesc = labeledEEG.event(evt_idx).bdf_condition_description;
                     end
                     
-                    % Update descriptions
                     labeledEEG.event(evt_idx).bdf_label_description = char(labelDescription);
                     if isempty(conditionDesc)
                         labeledEEG.event(evt_idx).bdf_full_description = char(labelDescription);
                     else
                         labeledEEG.event(evt_idx).bdf_full_description = [char(conditionDesc) ' ' char(labelDescription)];
                     end
+                end
+                
+                % Resolve word text for conflict events
+                cEvt = labeledEEG.event(evt_idx);
+                cWordText = '';
+                if isfield(cEvt, 'current_word') && ischar(cEvt.current_word) && ~isempty(cEvt.current_word)
+                    try
+                        [rn, wn] = parse_word_region(cEvt.current_word);
+                        wf = sprintf('region%d_words', rn);
+                        if isfield(cEvt, wf) && ~isempty(cEvt.(wf))
+                            ws = cEvt.(wf);
+                            if iscell(ws) && wn <= length(ws)
+                                cWordText = strtrim(ws{wn});
+                            end
+                        end
+                    catch
+                    end
+                end
+                labeledEEG.event(evt_idx).current_word_text = cWordText;
+                
+                % Set type based on eventFormat
+                switch eventFormat
+                    case 'numeric'
+                        labeledEEG.event(evt_idx).type = new_code;
+                    case 'description'
+                        descType = build_description_type(conditionDesc, labelDescription);
+                        if isempty(descType)
+                            labeledEEG.event(evt_idx).type = new_code;
+                        else
+                            labeledEEG.event(evt_idx).type = descType;
+                        end
+                    case 'description_word'
+                        descType = build_description_type(conditionDesc, labelDescription);
+                        if isempty(descType)
+                            labeledEEG.event(evt_idx).type = new_code;
+                        elseif ~isempty(cWordText)
+                            labeledEEG.event(evt_idx).type = [descType ' ' cWordText];
+                        else
+                            labeledEEG.event(evt_idx).type = descType;
+                        end
+                    case 'region_content'
+                        regionText = '';
+                        if isfield(cEvt, 'current_word') && ischar(cEvt.current_word) && ~isempty(cEvt.current_word)
+                            try
+                                [rn2, ~] = parse_word_region(cEvt.current_word);
+                                tf = sprintf('region%d_text', rn2);
+                                if isfield(cEvt, tf) && ischar(cEvt.(tf)) && ~isempty(cEvt.(tf))
+                                    regionText = strtrim(cEvt.(tf));
+                                end
+                            catch
+                            end
+                        end
+                        if ~isempty(regionText)
+                            labeledEEG.event(evt_idx).type = regionText;
+                        else
+                            labeledEEG.event(evt_idx).type = new_code;
+                        end
+                    case 'original'
+                        % Leave type unchanged
+                    otherwise
+                        labeledEEG.event(evt_idx).type = new_code;
                 end
             end
             fprintf('Replaced %d conflicting labels.\n', length(conflictingEvents));
@@ -1231,5 +1346,20 @@ function [choice, rememberAll] = show_conflict_dialog(conflictingEvents, dataset
             uiresume(hDlg);
             delete(hDlg);
         end
+    end
+end
+
+%% Helper function: build_description_type
+function descType = build_description_type(conditionDesc, labelDescription)
+    conditionDesc = char(conditionDesc);
+    labelDescription = char(labelDescription);
+    if isempty(conditionDesc) && isempty(labelDescription)
+        descType = '';
+    elseif isempty(conditionDesc)
+        descType = labelDescription;
+    elseif isempty(labelDescription)
+        descType = conditionDesc;
+    else
+        descType = [conditionDesc ' ' labelDescription];
     end
 end

--- a/functions/parse_word_region.m
+++ b/functions/parse_word_region.m
@@ -1,0 +1,48 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+% Author: Brandon Snyder
+
+function [major, minor] = parse_word_region(word_region)
+% PARSE_WORD_REGION - Parse a word region identifier into region and word numbers
+%
+% Handles two formats:
+%   "4.2"  -> region 4, word 2
+%   "x1_1" -> region 1, word 1
+%
+% Usage:
+%   [regionNum, wordNum] = parse_word_region(word_region)
+
+if contains(word_region, '.')
+    parts = split(word_region, '.');
+    major = str2double(parts{1});
+    minor = str2double(parts{2});
+elseif contains(word_region, '_')
+    parts = split(word_region, '_');
+    region_part = regexprep(parts{1}, '^x', '');
+    major = str2double(region_part);
+    minor = str2double(parts{2});
+else
+    error('Unknown word region format: %s', word_region);
+end
+
+if isnan(major) || isnan(minor)
+    error('Failed to parse word region: %s', word_region);
+end
+
+end

--- a/functions/process_eyesort_batch.m
+++ b/functions/process_eyesort_batch.m
@@ -213,6 +213,9 @@ for i = 1:length(datasetFiles)
             if isfield(config, 'items') && ~isempty(config.items)
                 filter_args = [filter_args, {'items', config.items}];
             end
+            if isfield(config, 'eventFormat') && ~isempty(config.eventFormat)
+                filter_args = [filter_args, {'eventFormat', config.eventFormat}];
+            end
             
             [EEG, ~] = label_datasets_core(EEG, filter_args{:});
         else

--- a/functions/trial_labeling.m
+++ b/functions/trial_labeling.m
@@ -515,32 +515,6 @@ function EEG = trial_labeling(EEG, startCode, endCode, conditionTriggers, itemTr
     fprintf('Done computing region tracking and pass fields.\n');
 end
 
-% Parses word region identifiers into region number and word number
-% Handles two formats:
-% - "4.2" -> region 4, word 2
-% - "x1_1" -> region 1, word 1
-function [major, minor] = parse_word_region(word_region)
-    % Parses a word region string (e.g., "4.2" or "x1_1") into its major (region) and minor (word) parts.
-    if contains(word_region, '.')
-        parts = split(word_region, '.');
-        major = str2double(parts{1});
-        minor = str2double(parts{2});
-    elseif contains(word_region, '_')
-        parts = split(word_region, '_');
-        % Remove 'x' from the first part if it exists
-        region_part = regexprep(parts{1}, '^x', '');
-        major = str2double(region_part);
-        minor = str2double(parts{2});
-    else
-        error('Unknown word region format: %s', word_region);
-    end
-    
-    if isnan(major) || isnan(minor)
-        error('Failed to parse word region: %s', word_region);
-    end
-end
-
-
 % Determines which word a fixation falls into based on x-coordinate
 % Returns the word identifier or empty string if no match found
 function currentWord = determine_word_region(event, fixationXField)

--- a/pop_functions/pop_convert_event_codes.m
+++ b/pop_functions/pop_convert_event_codes.m
@@ -1,0 +1,343 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+% Author: Brandon Snyder
+
+function [EEG, com] = pop_convert_event_codes(EEG)
+% POP_CONVERT_EVENT_CODES - GUI for converting EEG.event.type format
+%
+% Allows the user to switch between different event marker formats for
+% events that have already been labeled by EyeSort. The canonical CCRRLL
+% code stored in eyesort_full_code is never modified.
+%
+% In single-dataset mode, operates on the EEG argument (or base workspace
+% EEG). In batch mode (after pop_label_datasets has processed multiple
+% datasets), operates on every *_processed.set file found in the batch
+% output directory.
+%
+% Usage:
+%   [EEG, com] = pop_convert_event_codes(EEG)
+
+com = '';
+
+% Detect whether we should run in batch mode by looking for an output
+% directory left behind by pop_label_datasets.
+batchDir = '';
+try
+    candidate = evalin('base', 'eyesort_batch_output_dir');
+    if ischar(candidate) && ~isempty(candidate) && exist(candidate, 'dir')
+        batchDir = candidate;
+    end
+catch
+end
+
+if isempty(batchDir)
+    try
+        candidate = evalin('base', 'eyesort_single_output_dir');
+        if ischar(candidate) && ~isempty(candidate) && exist(candidate, 'dir')
+            batchDir = candidate;
+        end
+    catch
+    end
+end
+
+% Find labeled .set files in the batch directory (if any).
+batchFiles = {};
+if ~isempty(batchDir)
+    listing = dir(fullfile(batchDir, '*_processed.set'));
+    if isempty(listing)
+        listing = dir(fullfile(batchDir, '*_labeled.set'));
+    end
+    for fi = 1:length(listing)
+        batchFiles{end+1} = fullfile(listing(fi).folder, listing(fi).name); %#ok<AGROW>
+    end
+end
+
+batchMode = ~isempty(batchFiles);
+
+% Acquire a sample EEG: in batch mode, load just the first file (without
+% touching the base workspace). In single mode, use the provided arg or
+% pull from base.
+sampleEEG = [];
+if batchMode
+    fprintf('Convert Event Codes: batch mode detected (%d dataset(s) in %s)\n', ...
+        length(batchFiles), batchDir);
+    try
+        sampleEEG = pop_loadset(batchFiles{1});
+    catch ME
+        errordlg(sprintf('Failed to load %s: %s', batchFiles{1}, ME.message), ...
+            'Convert Event Codes');
+        return;
+    end
+else
+    if nargin < 1 || isempty(EEG)
+        try
+            EEG = evalin('base', 'EEG'); %#ok<NASGU> used in nested on_apply
+        catch
+            errordlg('No EEG dataset available.', 'Convert Event Codes');
+            return;
+        end
+    end
+    sampleEEG = EEG;
+end
+
+if isempty(sampleEEG) || ~isfield(sampleEEG, 'event') || isempty(sampleEEG.event)
+    errordlg('EEG dataset has no events.', 'Convert Event Codes');
+    return;
+end
+
+if ~isfield(sampleEEG.event, 'eyesort_full_code')
+    errordlg(['No labeled events found (eyesort_full_code field missing). ', ...
+              'Please run EyeSort labeling first.'], 'Convert Event Codes');
+    return;
+end
+
+formatLabels = { ...
+    'Numeric code (CCRRLL) - ERPLAB compatible', ...
+    'Condition and label description', ...
+    'Condition, label, and fixated word', ...
+    'Region text content', ...
+    'Revert to original event codes'};
+formatValues = {'numeric', 'description', 'description_word', 'region_content', 'original'};
+
+currentFormat = 'numeric';
+if isfield(sampleEEG, 'eyesort_event_format') && ischar(sampleEEG.eyesort_event_format)
+    currentFormat = sampleEEG.eyesort_event_format;
+end
+currentIdx = find(strcmp(formatValues, currentFormat), 1);
+if isempty(currentIdx), currentIdx = 1; end
+
+previewEvent = [];
+for i = 1:length(sampleEEG.event)
+    if isfield(sampleEEG.event(i), 'eyesort_full_code') && ...
+       ischar(sampleEEG.event(i).eyesort_full_code) && ~isempty(sampleEEG.event(i).eyesort_full_code)
+        previewEvent = sampleEEG.event(i);
+        break;
+    end
+end
+
+previewStrings = cell(1, length(formatValues));
+for fi = 1:length(formatValues)
+    previewStrings{fi} = build_preview(previewEvent, formatValues{fi});
+end
+
+% Build mode description first so we can size the dialog to fit it.
+if batchMode
+    modeStr = sprintf('Batch mode: will rewrite event types in %d dataset file(s) in:\n%s', ...
+        length(batchFiles), batchDir);
+    modeRowH = 50;
+else
+    modeStr = ['Single dataset mode: will rewrite EEG.event.type for the current dataset. ', ...
+               'The internal CCRRLL code (eyesort_full_code) is always preserved.'];
+    modeRowH = 60;
+end
+
+% Layout constants
+pad        = 15;
+dlgW       = 560;
+titleH     = 28;
+modeGapTop = 6;
+popupH     = 28;
+popupGap   = 12;
+labelH     = 22;
+previewH   = 44;
+btnH       = 32;
+btnRowH    = btnH + 25;
+
+dlgH = pad + titleH + modeGapTop + modeRowH + popupGap + popupH + ...
+       popupGap + labelH + 4 + previewH + btnRowH + pad;
+
+screenSize = get(0, 'ScreenSize');
+dlgX = (screenSize(3) - dlgW) / 2;
+dlgY = (screenSize(4) - dlgH) / 2;
+
+hDlg = figure('Name', 'Modify Event Marker Format', ...
+    'NumberTitle', 'off', 'MenuBar', 'none', 'ToolBar', 'none', ...
+    'Resize', 'off', 'Position', [dlgX dlgY dlgW dlgH], ...
+    'WindowStyle', 'modal', 'CloseRequestFcn', @on_cancel);
+
+y = dlgH - pad - titleH;
+uicontrol(hDlg, 'Style', 'text', ...
+    'String', 'Select Event Marker Format:', ...
+    'FontWeight', 'bold', 'FontSize', 11, ...
+    'Position', [pad y dlgW-2*pad titleH], ...
+    'HorizontalAlignment', 'left');
+
+y = y - modeGapTop - modeRowH;
+uicontrol(hDlg, 'Style', 'text', ...
+    'String', modeStr, ...
+    'FontSize', 9, ...
+    'Position', [pad y dlgW-2*pad modeRowH], ...
+    'HorizontalAlignment', 'left');
+
+y = y - popupGap - popupH;
+hPopup = uicontrol(hDlg, 'Style', 'popupmenu', ...
+    'String', formatLabels, 'Value', currentIdx, ...
+    'FontSize', 10, ...
+    'Position', [pad y dlgW-2*pad popupH], ...
+    'Callback', @on_format_change);
+
+y = y - popupGap - labelH;
+uicontrol(hDlg, 'Style', 'text', ...
+    'String', 'Preview (first labeled event):', ...
+    'FontWeight', 'bold', 'FontSize', 10, ...
+    'Position', [pad y dlgW-2*pad labelH], ...
+    'HorizontalAlignment', 'left');
+
+y = y - 4 - previewH;
+hPreview = uicontrol(hDlg, 'Style', 'text', ...
+    'String', previewStrings{currentIdx}, ...
+    'FontSize', 10, 'ForegroundColor', [0.1 0.3 0.6], ...
+    'Position', [pad y dlgW-2*pad previewH], ...
+    'HorizontalAlignment', 'left');
+
+btnW = 120;
+btnY = pad;
+uicontrol(hDlg, 'Style', 'pushbutton', 'String', 'Apply', ...
+    'FontSize', 10, 'Position', [dlgW/2 - btnW - 10 btnY btnW btnH], ...
+    'Callback', @on_apply);
+uicontrol(hDlg, 'Style', 'pushbutton', 'String', 'Cancel', ...
+    'FontSize', 10, 'Position', [dlgW/2 + 10 btnY btnW btnH], ...
+    'Callback', @on_cancel);
+
+uiwait(hDlg);
+
+    function on_format_change(~, ~)
+        idx = get(hPopup, 'Value');
+        set(hPreview, 'String', previewStrings{idx});
+    end
+
+    function on_apply(~, ~)
+        idx = get(hPopup, 'Value');
+        selectedFormat = formatValues{idx};
+        if ishandle(hDlg), delete(hDlg); end
+
+        if batchMode
+            apply_batch(batchFiles, selectedFormat);
+            com = sprintf('%% pop_convert_event_codes batch: %d file(s) -> %s', ...
+                length(batchFiles), selectedFormat);
+            msgbox(sprintf('Converted %d dataset(s) to ''%s'' format.', ...
+                length(batchFiles), selectedFormat), ...
+                'Conversion Complete', 'help');
+        else
+            EEG = convert_event_codes(EEG, selectedFormat);
+            com = sprintf('EEG = convert_event_codes(EEG, ''%s'');', selectedFormat);
+            assignin('base', 'EEG', EEG);
+            msgbox(sprintf('Event codes converted to ''%s'' format.', selectedFormat), ...
+                'Conversion Complete', 'help');
+        end
+    end
+
+    function on_cancel(~, ~)
+        if ishandle(hDlg), delete(hDlg); end
+    end
+end
+
+%% Apply conversion to a list of dataset files, saving each in place.
+function apply_batch(files, fmt)
+    nFiles = length(files);
+    fprintf('Converting event codes in %d dataset(s) to format ''%s''...\n', nFiles, fmt);
+    h = waitbar(0, 'Converting event codes...', 'Name', 'Convert Event Codes');
+    cleanup = onCleanup(@() safe_delete(h));
+
+    for i = 1:nFiles
+        [folder, name, ext] = fileparts(files{i});
+        fname = [name ext];
+        try
+            waitbar((i-1)/nFiles, h, sprintf('Loading %s...', fname));
+            tmp = pop_loadset('filename', fname, 'filepath', folder);
+
+            if ~isfield(tmp, 'event') || isempty(tmp.event) || ...
+               ~isfield(tmp.event, 'eyesort_full_code')
+                fprintf('  Skipping %s: not labeled by EyeSort.\n', fname);
+                continue;
+            end
+
+            waitbar((i-0.5)/nFiles, h, sprintf('Converting %s...', fname));
+            tmp = convert_event_codes(tmp, fmt);
+
+            waitbar((i-0.25)/nFiles, h, sprintf('Saving %s...', fname));
+            pop_saveset(tmp, 'filename', fname, 'filepath', folder, 'savemode', 'twofiles');
+            fprintf('  Converted %d/%d: %s\n', i, nFiles, fname);
+        catch ME
+            warning('Failed to convert %s: %s', fname, ME.message);
+        end
+        clear tmp;
+    end
+    fprintf('Batch conversion complete.\n');
+end
+
+function safe_delete(h)
+    if ishandle(h), delete(h); end
+end
+
+%% Build a human-readable preview string for the given format
+function str = build_preview(evt, fmt)
+    if isempty(evt)
+        str = '(no labeled events to preview)';
+        return;
+    end
+    switch fmt
+        case 'numeric'
+            str = evt.eyesort_full_code;
+        case 'description'
+            if isfield(evt, 'bdf_full_description') && ~isempty(evt.bdf_full_description)
+                str = evt.bdf_full_description;
+            else
+                str = [evt.eyesort_full_code ' (no description available)'];
+            end
+        case 'description_word'
+            desc = '';
+            if isfield(evt, 'bdf_full_description') && ~isempty(evt.bdf_full_description)
+                desc = evt.bdf_full_description;
+            end
+            word = '';
+            if isfield(evt, 'current_word_text') && ~isempty(evt.current_word_text)
+                word = evt.current_word_text;
+            end
+            if ~isempty(desc) && ~isempty(word)
+                str = [desc ' ' word];
+            elseif ~isempty(desc)
+                str = desc;
+            else
+                str = [evt.eyesort_full_code ' (no description available)'];
+            end
+        case 'region_content'
+            str = '';
+            if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+                try
+                    [regionNum, ~] = parse_word_region(evt.current_word);
+                    textField = sprintf('region%d_text', regionNum);
+                    if isfield(evt, textField) && ischar(evt.(textField)) && ~isempty(evt.(textField))
+                        str = strtrim(evt.(textField));
+                    end
+                catch
+                end
+            end
+            if isempty(str)
+                str = [evt.eyesort_full_code ' (no region text available)'];
+            end
+        case 'original'
+            if isfield(evt, 'original_type') && ~isempty(evt.original_type)
+                str = evt.original_type;
+            else
+                str = '(original type not available)';
+            end
+    end
+    str = ['type = ''' str ''''];
+end

--- a/pop_functions/pop_label_datasets.m
+++ b/pop_functions/pop_label_datasets.m
@@ -150,13 +150,21 @@ function [EEG, com] = pop_label_datasets(EEG)
     % Create parts of the layout for non-region sections
     % geomhoriz and geomvert are built in parallel (one entry per GUI row).
     % geomvert controls relative row heights; the label-queue listbox gets 4x height.
+    eventFormatOptions = {'Numeric code (CCRRLL) - ERPLAB compatible', ...
+                          'Condition and label description', ...
+                          'Condition, label, and fixated word', ...
+                          'Region text content', ...
+                          'Keep original event codes'};
+    eventFormatValues  = {'numeric', 'description', 'description_word', 'region_content', 'original'};
+
     geomhoriz = { ...
         1, ...                % Configuration management
         [1 1 1], ...            % Load config, Load last config buttons
         [0.5 1], ...          % Label Description label + edit box (consolidated)
+        [0.5 1], ...          % Event Marker Format label + popup
         1, ...                % Time-Locked Region title (description folded in)
     };
-    geomvert = [1, 1, 1, 1];
+    geomvert = [1, 1, 1, 1, 1];
     
     uilist = { ...
         {'Style','text','String','Configuration Management:', 'FontWeight', 'bold'}, ...
@@ -167,6 +175,9 @@ function [EEG, com] = pop_label_datasets(EEG)
         ...
         {'Style','text','String','Label Description (used in BDF generation):', 'FontWeight', 'bold'}, ...
         {'Style','edit','String','','tag','edtLabelDescription','ForegroundColor',[0 0 0]}, ...
+        ...
+        {'Style','text','String','Select Event Marker Format:', 'FontWeight', 'bold'}, ...
+        {'Style','popupmenu','String', eventFormatOptions, 'tag','popEventFormat','Value',1}, ...
         ...
         {'Style','text','String','Time-Locked Region: (main region of interest for all label criteria)', 'FontWeight', 'bold'}, ...
     };
@@ -482,6 +493,13 @@ function [EEG, com] = pop_label_datasets(EEG)
             % Queue — restore all labels to pending_labels and refresh display
             pending_labels = result;
             update_queue_display();
+            % Restore event format from the first label config if available
+            if ~isempty(result) && isfield(result{1}, 'eventFormat')
+                fmtIdx = find(strcmp(eventFormatValues, result{1}.eventFormat), 1);
+                if ~isempty(fmtIdx)
+                    set(findobj('tag','popEventFormat'), 'Value', fmtIdx);
+                end
+            end
             msgbox(sprintf('Label queue loaded! %d label(s) added to the queue.\n\nClick "Apply All & Finish" to run them.', ...
                 length(pending_labels)), 'Load Complete', 'help');
         else
@@ -545,6 +563,9 @@ function [EEG, com] = pop_label_datasets(EEG)
                 config.labelDescription = config.labelDescription{1};
             end
             config.labelDescription = strtrim(config.labelDescription); % Trim whitespace from user input
+            
+            % Event format selection (session-wide, stored per config for reproducibility)
+            config.eventFormat = get_selected_event_format();
             
             % Store available regions for validation when loading
             config.availableRegions = regionNames;
@@ -663,6 +684,14 @@ function [EEG, com] = pop_label_datasets(EEG)
                 set(findobj('tag','edtLabelDescription'), 'String', config.labelDescription);
             end
             
+            % Apply event format selection
+            if isfield(config, 'eventFormat')
+                fmtIdx = find(strcmp(eventFormatValues, config.eventFormat), 1);
+                if ~isempty(fmtIdx)
+                    set(findobj('tag','popEventFormat'), 'Value', fmtIdx);
+                end
+            end
+            
         catch ME
             errordlg(['Error applying label configuration to GUI: ' ME.message], 'Apply Error');
         end
@@ -702,6 +731,21 @@ function [EEG, com] = pop_label_datasets(EEG)
         end
     end
 
+    % Read the event marker format from the GUI dropdown
+    function fmt = get_selected_event_format()
+        hPop = findobj('tag', 'popEventFormat');
+        if isempty(hPop)
+            fmt = 'numeric';
+            return;
+        end
+        idx = get(hPop, 'Value');
+        if idx >= 1 && idx <= length(eventFormatValues)
+            fmt = eventFormatValues{idx};
+        else
+            fmt = 'numeric';
+        end
+    end
+
     % Format a queued label config as a readable string for the listbox
     function str = format_label_for_display(cfg, idx)
         desc = '(no description)';
@@ -721,6 +765,9 @@ function [EEG, com] = pop_label_datasets(EEG)
     function apply_all_labels_single()
         nLabels = length(pending_labels);
         matched_counts = zeros(1, nLabels);
+        
+        % Read the session-wide event format selection
+        selectedEventFormat = get_selected_event_format();
         
         % Determine starting label count once before the loop so it is immune
         % to a stale or empty eyesort_label_count value in the struct
@@ -743,6 +790,7 @@ function [EEG, com] = pop_label_datasets(EEG)
                 if ~isempty(saved_conflict_resolution)
                     label_params = [label_params, {'conflictResolution', saved_conflict_resolution}];
                 end
+                label_params = [label_params, {'eventFormat', selectedEventFormat}];
                 [EEG, label_com, chosen] = label_datasets_core(EEG, label_params{:}, 'labelCount', currentLabelNum, 'showRegionMap', qi == 1);
                 com = label_com;
                 if ~isempty(chosen)
@@ -832,10 +880,20 @@ function [EEG, com] = pop_label_datasets(EEG)
             fdStr = sprintf('\n\nTrials by label+condition:\n%s', strjoin(fdLines, '\n'));
         end
 
+        formatDescriptions = struct( ...
+            'numeric', 'Events labeled with 6-digit codes (CCRRLL). CC = condition, RR = region, LL = label', ...
+            'description', 'Events labeled with condition + label descriptions (e.g., ''Identical PreTarget_NoSkip'')', ...
+            'description_word', 'Events labeled with condition + label + fixated word (e.g., ''Identical PreTarget_NoSkip JUMPED'')', ...
+            'region_content', 'Events labeled with region text content', ...
+            'original', 'Event codes left as original (pre-EyeSort) values');
+        if isfield(formatDescriptions, selectedEventFormat)
+            formatNote = formatDescriptions.(selectedEventFormat);
+        else
+            formatNote = 'Events labeled with 6-digit codes (CCRRLL).';
+        end
         summaryStr = sprintf(['Labeling complete!\n\n%d label(s) applied:\n%s%s\n\n' ...
-            'Events have been labeled with 6-digit codes (CCRRLL).\n' ...
-            'CC = condition, RR = region, LL = label'], ...
-            nLabels, strjoin(summaryLines, '\n'), fdStr);
+            '%s'], ...
+            nLabels, strjoin(summaryLines, '\n'), fdStr, formatNote);
         hMsg = msgbox(summaryStr, 'Labeling Complete', 'help');
         waitfor(hMsg);
         
@@ -886,6 +944,9 @@ function [EEG, com] = pop_label_datasets(EEG)
     % This reduces disk I/O from N×L loads+saves to N loads + N saves.
     % -----------------------------------------------------------------------
     function apply_all_labels_batch()
+        % Read the session-wide event format selection
+        selectedEventFormat = get_selected_event_format();
+
         % Determine the starting label count from the reference EEG already in
         % memory (loaded at the top of pop_label_datasets) — no extra disk read.
         if current_batch_label_count == 0
@@ -956,7 +1017,7 @@ function [EEG, com] = pop_label_datasets(EEG)
 
                         % Apply the label; capture any "remember" conflict choice so it
                         % propagates to subsequent datasets and labels in this run.
-                        [tempEEG, ~, newResolution] = label_datasets_core(tempEEG, label_params{:}, 'labelCount', labelNum, 'showRegionMap', qi == 1);
+                        [tempEEG, ~, newResolution] = label_datasets_core(tempEEG, label_params{:}, 'labelCount', labelNum, 'showRegionMap', qi == 1, 'eventFormat', selectedEventFormat);
                         if ~isempty(newResolution)
                             saved_conflict_resolution = newResolution;
                         end


### PR DESCRIPTION
feat(event-marker-format): configurable EEG.event.type formats and post-hoc conversion
- Added "Modify Event Marker Format" under the EyeSort menu (calls pop_convert_event_codes) with convert_event_codes.m to rewrite labeled events' types without changing eyesort_full_code (numeric CCRRLL, description, description_word, region_content, or restore original)
- Added parse_word_region.m and current_word_text on labeled events so description_word and region_content formats resolve the fixated word and region text correctly
- Plumbed eventFormat through convert_config_to_params, process_eyesort_batch, pop_label_datasets, and label_datasets_core; store eyesort_event_format on the labeled dataset
- label_datasets_core now always keeps eyesort_*_code and eyesort_full_code as the canonical CCRRLL representation and sets EEG.event.type according to eventFormat (including conflict updates)
- Updated EyeSort version to 0.5.1