### PR TITLE
Feat/script history

### DIFF
--- a/eegplugin_eyesort.m
+++ b/eegplugin_eyesort.m
@@ -125,6 +125,14 @@ function currvers = eegplugin_eyesort(fig, ~, ~)
             uimenu(submenu, 'label', 'Modify Event Code Format', 'separator', 'off', ...
                 'callback', @(src,event) try_callback(@pop_convert_event_codes, src, event));
             
+            historyScriptsMenu = uimenu(submenu, 'Label', 'History Scripts', ...
+                'separator', 'on', 'Tag', 'EyeSort_HistoryScripts', ...
+                'userdata', 'startup:on;continuous:on;epoch:on;study:on;erpset:on');
+
+            uimenu(historyScriptsMenu, 'Label', 'Save processing history script', ...
+                'Tag', 'EyeSort_SaveSessionHistory', ...
+                'callback', @(src,event) try_callback(@save_eyesort_processing_script, src, event));
+            
             uimenu(submenu, 'label', 'Help', 'separator', 'on', ...
                    'callback', @(src,event) try_callback(@help_button, src, event));
 
@@ -136,10 +144,32 @@ function currvers = eegplugin_eyesort(fig, ~, ~)
     end
 end
 
+% No-output wrapper so try_callback does not treat the script path as history.
+function save_eyesort_processing_script()
+    save_eyesort_session_script();
+end
+
 % Helper function for safer callback execution
 function try_callback(callback_fn, ~, ~)
     try
-        callback_fn();
+        com = '';
+        EEG = [];
+        outputCount = nargout(callback_fn);
+        if outputCount >= 2
+            [EEG, com] = callback_fn();
+        elseif outputCount == 1
+            output = callback_fn();
+            if ischar(output) || isstring(output)
+                com = output;
+            else
+                EEG = output;
+            end
+        else
+            callback_fn();
+        end
+        if ~isempty(com)
+            record_eyesort_history(com, EEG);
+        end
         % Update menu state after successful operations (especially dataset loading)
         update_eyesort_menu_state();
     catch ME

--- a/eyesort_default_values.m
+++ b/eyesort_default_values.m
@@ -1,2 +1,2 @@
 % Current EyeSort version
-eyesortver = '0.5.1';
+eyesortver = '0.6';

--- a/functions/append_eyesort_grand_totals.m
+++ b/functions/append_eyesort_grand_totals.m
@@ -1,0 +1,49 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+
+function append_eyesort_grand_totals(csvPath)
+% APPEND_EYESORT_GRAND_TOTALS Append TOTAL rows to an EyeSort summary CSV.
+
+fid = fopen(csvPath, 'r');
+if fid == -1
+    return;
+end
+fgetl(fid);
+rows = {};
+while ~feof(fid)
+    line = strtrim(fgetl(fid));
+    if ~isempty(line)
+        rows{end+1} = line; %#ok<AGROW>
+    end
+end
+fclose(fid);
+
+if isempty(rows)
+    return;
+end
+
+fdMap = containers.Map('KeyType', 'char', 'ValueType', 'double');
+for rowIdx = 1:numel(rows)
+    parts = strsplit(rows{rowIdx}, ',');
+    if numel(parts) >= 3
+        key = strjoin(parts(2:end-1), ',');
+        val = str2double(parts{end});
+        if isKey(fdMap, key)
+            fdMap(key) = fdMap(key) + val;
+        else
+            fdMap(key) = val;
+        end
+    end
+end
+
+fid = fopen(csvPath, 'a');
+if fid == -1
+    return;
+end
+for keyCell = keys(fdMap)
+    fprintf(fid, 'TOTAL,%s,%d\n', keyCell{1}, fdMap(keyCell{1}));
+end
+fclose(fid);
+end

--- a/functions/batch_label_utils.m
+++ b/functions/batch_label_utils.m
@@ -215,7 +215,6 @@ try
         if contains(file_path, 'eyesort_temp') && contains(file_path, '_textia_temp.set')
             if exist(file_path, 'file')
                 delete(file_path);
-                fprintf('Cleaned up temporary file: %s\n', file_path);
             end
         end
     end
@@ -224,7 +223,6 @@ try
     if exist(temp_dir, 'dir')
         try
             rmdir(temp_dir);
-            fprintf('Cleaned up temporary directory: %s\n', temp_dir);
         catch
             % Directory might not be empty or have permissions issues, ignore
         end

--- a/functions/convert_config_to_params.m
+++ b/functions/convert_config_to_params.m
@@ -69,23 +69,23 @@ end
 
 % Fixation options
 fixationOptions = [];
-if isfield(config, 'fixFirstInRegion') && config.fixFirstInRegion
+if isfield(config, 'fixSingleFixation') && config.fixSingleFixation
+    fixationOptions(end+1) = 1;
+end
+if isfield(config, 'fixFirstOfMultiple') && config.fixFirstOfMultiple
     fixationOptions(end+1) = 2;
 end
-if isfield(config, 'fixSingleFixation') && config.fixSingleFixation
+if isfield(config, 'fixSecondMultiple') && config.fixSecondMultiple
     fixationOptions(end+1) = 3;
 end
-if isfield(config, 'fixSecondMultiple') && config.fixSecondMultiple
+if isfield(config, 'fixAllSubsequent') && config.fixAllSubsequent
     fixationOptions(end+1) = 4;
 end
-if isfield(config, 'fixAllSubsequent') && config.fixAllSubsequent
+if isfield(config, 'fixLastInRegion') && config.fixLastInRegion
     fixationOptions(end+1) = 5;
 end
-if isfield(config, 'fixLastInRegion') && config.fixLastInRegion
-    fixationOptions(end+1) = 6;
-end
 if isempty(fixationOptions)
-    fixationOptions = 1;
+    fixationOptions = 0;
 end
 label_params{end+1} = 'fixationOptions';
 label_params{end+1} = fixationOptions;
@@ -122,6 +122,12 @@ label_params{end+1} = saccadeOutOptions;
 if isfield(config, 'eventFormat') && ~isempty(config.eventFormat)
     label_params{end+1} = 'eventFormat';
     label_params{end+1} = config.eventFormat;
+end
+
+% Label description
+if isfield(config, 'labelDescription') && ~isempty(config.labelDescription)
+    label_params{end+1} = 'labelDescription';
+    label_params{end+1} = config.labelDescription;
 end
 
 end 

--- a/functions/generate_bdf_file.m
+++ b/functions/generate_bdf_file.m
@@ -26,6 +26,7 @@ function generate_bdf_file(varargin)
 %   >> generate_bdf_file(EEG);                % Generate BDF from single EEG dataset
 %   >> generate_bdf_file(ALLEEG);             % Generate BDF from ALLEEG structure
 %   >> generate_bdf_file(EEG, outputFile);    % Specify output file path
+%   >> generate_bdf_file(outputDir, outputFile); % Process labeled .set files in a directory
 %
 % Inputs:
 %   EEG        - EEGLAB EEG structure with labeled events (optional)
@@ -40,6 +41,17 @@ function generate_bdf_file(varargin)
 %   - Last 2 digits: Label code (01-99)
 %
 % See also: pop_label_datasets
+
+    % Non-interactive directory mode for generated EyeSort scripts.
+    if nargin >= 1 && (ischar(varargin{1}) || isstring(varargin{1})) && exist(char(varargin{1}), 'dir')
+        outputDir = char(varargin{1});
+        if nargin >= 2
+            process_from_directory(outputDir, varargin{2});
+        else
+            process_from_directory(outputDir);
+        end
+        return;
+    end
 
     % Check for input arguments
     if nargin < 1

--- a/functions/next_available_eyesort_summary_file.m
+++ b/functions/next_available_eyesort_summary_file.m
@@ -1,0 +1,15 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+
+function summaryPath = next_available_eyesort_summary_file(outputDir)
+% NEXT_AVAILABLE_EYESORT_SUMMARY_FILE Return the next unused summary CSV path.
+
+sessionIdx = 1;
+summaryPath = fullfile(outputDir, sprintf('eyesort_labeling_summary_%03d.csv', sessionIdx));
+while exist(summaryPath, 'file')
+    sessionIdx = sessionIdx + 1;
+    summaryPath = fullfile(outputDir, sprintf('eyesort_labeling_summary_%03d.csv', sessionIdx));
+end
+end

--- a/functions/record_eyesort_history.m
+++ b/functions/record_eyesort_history.m
@@ -1,0 +1,76 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function EEG = record_eyesort_history(com, EEG)
+    % Record an EyeSort command in EEGLAB session and dataset history.
+
+    if nargin < 1 || isempty(com)
+        if nargin < 2
+            EEG = [];
+        end
+        return;
+    end
+
+    if isstring(com)
+        com = char(com);
+    end
+
+    if ~ischar(com) || isempty(strtrim(com))
+        if nargin < 2
+            EEG = [];
+        end
+        return;
+    end
+
+    if nargin < 2
+        try
+            EEG = evalin('base', 'EEG');
+        catch
+            EEG = [];
+        end
+    end
+
+    try
+        if ~isempty(EEG) && isstruct(EEG)
+            EEG = eegh(com, EEG);
+            assignin('base', 'EEG', EEG);
+            sync_current_alleeg(EEG);
+        else
+            eegh(com);
+        end
+    catch ME
+        warning('EyeSort:HistoryRecord', 'Failed to record EyeSort history: %s', ME.message);
+    end
+end
+
+function sync_current_alleeg(EEG)
+    if numel(EEG) ~= 1
+        return;
+    end
+
+    try
+        ALLEEG = evalin('base', 'ALLEEG');
+        CURRENTSET = evalin('base', 'CURRENTSET');
+        if ~isempty(ALLEEG) && ~isempty(CURRENTSET) && CURRENTSET >= 1 && CURRENTSET <= numel(ALLEEG)
+            ALLEEG(CURRENTSET) = EEG;
+            assignin('base', 'ALLEEG', ALLEEG);
+        end
+    catch
+        % ALLEEG/CURRENTSET are optional for batch workflows.
+    end
+end

--- a/functions/save_eyesort_session_script.m
+++ b/functions/save_eyesort_session_script.m
@@ -1,0 +1,512 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function scriptPath = save_eyesort_session_script(varargin)
+    % SAVE_EYESORT_SESSION_SCRIPT - Export a GUI-free EyeSort processing script.
+    %
+    % Captures the EyeSort pipeline settings recorded during GUI use (Steps 1–4)
+    % and writes a standalone .m file that re-runs Text IA, optional column import,
+    % label queue application, and optional BDF generation without opening GUIs.
+    %
+    % Generated scripts default to scanning inputDir for *.set files so users
+    % can edit one directory path when reusing the pipeline for a new batch. The
+    % exact Step 1 file list is also written as a commented fallback.
+    %
+    % Sidecar files (Text IA config, label queue, interest-area text files) are
+    % copied next to the saved script so the bundle is portable.
+    %
+    % Inputs:
+    %   scriptPathOut - optional full path for the output script; skips uiputfile
+    %                   (used by automated tests). Legacy scope arguments are
+    %                   accepted but ignored.
+    %
+    % Output:
+    %   scriptPath   - path to the written script, or '' if the user cancelled
+    %
+    % See also: update_eyesort_session_state, record_eyesort_history
+
+    scriptPathOut = parse_script_path_arg(varargin{:});
+
+    % Recover pipeline settings from base workspace or cache, then validate.
+    state = load_session_state();
+    state = fill_state_from_workspace(state);
+    validate_session_state(state);
+
+    % Generated scripts use inputDir by default, but document the exact Step 1 files.
+    inputDir = get_input_dir(state);
+    inputFiles = get_input_files(state);
+
+    % Resolve output path (dialog or caller-supplied path for tests).
+    if ~isempty(scriptPathOut)
+        scriptPath = char(scriptPathOut);
+        [filepath, baseName, ext] = fileparts(scriptPath);
+        if isempty(ext)
+            ext = '.m';
+        end
+        if isempty(filepath)
+            filepath = pwd;
+        end
+        scriptPath = fullfile(filepath, [baseName ext]);
+    else
+        defaultName = 'eyesort_processing_script.m';
+        [filename, filepath] = uiputfile('*.m', 'Save EyeSort processing script', defaultName);
+        if isequal(filename, 0)
+            scriptPath = '';
+            return;
+        end
+        scriptPath = fullfile(filepath, filename);
+    end
+    [~, baseName] = fileparts(scriptPath);
+
+    % Bundle portable sidecars beside the script and rewrite Text IA paths.
+    textConfigPath = copy_sidecar(state.textIAConfigPath, filepath, [baseName '_text_ia_config.mat']);
+    localize_text_ia_files(textConfigPath, filepath, baseName);
+    labelQueuePath = '';
+    if isfield(state, 'labelQueueConfigPath') && ~isempty(state.labelQueueConfigPath) && exist(state.labelQueueConfigPath, 'file')
+        labelQueuePath = copy_sidecar(state.labelQueueConfigPath, filepath, [baseName '_label_queue.mat']);
+    end
+
+    fid = fopen(scriptPath, 'w');
+    if fid == -1
+        error('Could not open script for writing: %s', scriptPath);
+    end
+
+    cleanupObj = onCleanup(@() fclose(fid));
+
+    % --- Generated script: setup ---
+    fprintf(fid, '%% EyeSort processing script generated on %s\n', datestr(now));
+    fprintf(fid, '%% Re-runs the EyeSort pipeline without opening EyeSort GUIs.\n\n');
+    fprintf(fid, 'clear EEG;\n\n');
+    fprintf(fid, 'pluginDir = %s;\n', matlab_literal(plugin_root()));
+    fprintf(fid, 'addpath(genpath(pluginDir));\n\n');
+    fprintf(fid, 'inputDir = %s; %% edit this path to process a different batch\n', matlab_literal(inputDir));
+    fprintf(fid, 'datasetFiles = dir(fullfile(inputDir, ''*.set''));\n');
+    fprintf(fid, 'inputFiles = arrayfun(@(f) fullfile(f.folder, f.name), datasetFiles, ''UniformOutput'', false);\n');
+    fprintf(fid, 'if isempty(inputFiles)\n');
+    fprintf(fid, '    error(''No .set files found in inputDir: %%s'', inputDir);\n');
+    fprintf(fid, 'end\n\n');
+    fprintf(fid, '%% Files selected in EyeSort Step 1.\n');
+    fprintf(fid, '%% To process only this original selection, comment out the inputDir scan above\n');
+    fprintf(fid, '%% and uncomment the inputFiles block below.\n');
+    write_commented_cellstr_assignment(fid, 'inputFiles', inputFiles);
+    fprintf(fid, '\n');
+    fprintf(fid, 'outputDir = %s;\n', matlab_literal(get_output_dir(state, filepath)));
+    fprintf(fid, 'textIAConfig = %s;\n', matlab_literal(textConfigPath));
+    fprintf(fid, 'labelQueueConfig = %s;\n', matlab_literal(labelQueuePath));
+    write_cellstr_assignment(fid, 'importColumns', get_import_columns(state));
+    fprintf(fid, 'conflictResolution = %s; %% change to ''no'' if you prefer to keep existing labels\n', ...
+        matlab_literal(get_conflict_resolution(state)));
+    fprintf(fid, 'generateBDF = %s; %% set false to skip BINLISTER BDF generation\n', logical_literal(should_generate_bdf(state, labelQueuePath)));
+    fprintf(fid, 'generateSummary = true; %% set false to skip the labeling summary CSV\n');
+    fprintf(fid, 'bdfOutputFile = fullfile(outputDir, ''eyesort_bins.txt'');\n');
+    fprintf(fid, 'summaryOutputFile = next_available_eyesort_summary_file(outputDir);\n\n');
+
+    % --- Generated script: per-dataset pipeline loop ---
+    fprintf(fid, 'if ~exist(outputDir, ''dir'')\n');
+    fprintf(fid, '    mkdir(outputDir);\n');
+    fprintf(fid, 'end\n\n');
+    fprintf(fid, 'textCfg = load_text_ia_config(textIAConfig);\n');
+    fprintf(fid, 'txtFilePath = textCfg.txtFileList;\n');
+    fprintf(fid, 'if iscell(txtFilePath)\n');
+    fprintf(fid, '    txtFilePath = txtFilePath{1};\n');
+    fprintf(fid, 'end\n\n');
+    fprintf(fid, 'summaryRows = {};\n\n');
+
+    fprintf(fid, 'for fileIdx = 1:numel(inputFiles)\n');
+    fprintf(fid, '    inputFile = inputFiles{fileIdx};\n');
+    fprintf(fid, '    [~, datasetName] = fileparts(inputFile);\n');
+    fprintf(fid, '    fprintf(''\\n=== EyeSort script %%d/%%d: %%s ===\\n'', fileIdx, numel(inputFiles), datasetName);\n\n');
+    fprintf(fid, '    EEG = pop_loadset(''filename'', inputFile);\n');
+    fprintf(fid, '    EEG = compute_text_based_ia(EEG, textIAConfig, ''reportMode'', ''command'');\n\n');
+    fprintf(fid, '    if ~isempty(importColumns)\n');
+    fprintf(fid, '        EEG = import_ia_columns(EEG, txtFilePath, textCfg.conditionColName, textCfg.itemColName, importColumns, ''command'');\n');
+    fprintf(fid, '    end\n\n');
+    fprintf(fid, '    if ~isempty(labelQueueConfig) && exist(labelQueueConfig, ''file'')\n');
+    fprintf(fid, '        labelQueue = load_label_config(labelQueueConfig);\n');
+    fprintf(fid, '        if ~iscell(labelQueue)\n');
+    fprintf(fid, '            labelQueue = {labelQueue};\n');
+    fprintf(fid, '        end\n');
+    fprintf(fid, '        startLabelCount = 0;\n');
+    fprintf(fid, '        if isfield(EEG, ''eyesort_label_count'') && ~isempty(EEG.eyesort_label_count) && EEG.eyesort_label_count >= 0\n');
+    fprintf(fid, '            startLabelCount = EEG.eyesort_label_count;\n');
+    fprintf(fid, '        end\n');
+    fprintf(fid, '        for labelIdx = 1:numel(labelQueue)\n');
+    fprintf(fid, '            labelParams = convert_config_to_params(labelQueue{labelIdx});\n');
+    fprintf(fid, '            preFD = {};\n');
+    fprintf(fid, '            if generateSummary && isfield(EEG, ''event'') && isfield(EEG.event, ''bdf_full_description'')\n');
+    fprintf(fid, '                preFD = {EEG.event.bdf_full_description};\n');
+    fprintf(fid, '            end\n');
+    fprintf(fid, '            [EEG, ~] = label_datasets_core(EEG, labelParams{:}, ...\n');
+    fprintf(fid, '                ''labelCount'', startLabelCount + labelIdx, ...\n');
+    fprintf(fid, '                ''conflictResolution'', conflictResolution, ...\n');
+    fprintf(fid, '                ''showRegionMap'', false);\n');
+    fprintf(fid, '            if generateSummary && isfield(EEG, ''event'') && isfield(EEG.event, ''bdf_full_description'')\n');
+    fprintf(fid, '                postFD = {EEG.event.bdf_full_description};\n');
+    fprintf(fid, '                preExpanded = repmat({''''}, size(postFD));\n');
+    fprintf(fid, '                nPre = min(numel(preFD), numel(postFD));\n');
+    fprintf(fid, '                if nPre > 0\n');
+    fprintf(fid, '                    preExpanded(1:nPre) = preFD(1:nPre);\n');
+    fprintf(fid, '                end\n');
+    fprintf(fid, '                isNew = ~cellfun(@isempty, postFD) & ~strcmp(postFD, preExpanded);\n');
+    fprintf(fid, '                newlyFD = postFD(isNew);\n');
+    fprintf(fid, '                uniqueNewFD = unique(newlyFD);\n');
+    fprintf(fid, '                for summaryIdx = 1:numel(uniqueNewFD)\n');
+    fprintf(fid, '                    summaryRows{end+1} = sprintf(''%%s,%%s,%%d'', datasetName, uniqueNewFD{summaryIdx}, sum(strcmp(newlyFD, uniqueNewFD{summaryIdx}))); %%#ok<SAGROW>\n');
+    fprintf(fid, '                end\n');
+    fprintf(fid, '            end\n');
+    fprintf(fid, '        end\n');
+    fprintf(fid, '    end\n\n');
+    fprintf(fid, '    outputPath = fullfile(outputDir, [datasetName ''_processed.set'']);\n');
+    fprintf(fid, '    pop_saveset(EEG, ''filename'', outputPath, ''savemode'', ''twofiles'');\n');
+    fprintf(fid, '    fprintf(''Saved: %%s\\n'', outputPath);\n');
+    fprintf(fid, 'end\n\n');
+
+    % --- Generated script: optional labeling summary CSV ---
+    fprintf(fid, 'if generateSummary\n');
+    fprintf(fid, '    if isempty(summaryRows)\n');
+    fprintf(fid, '        fprintf(''\\nNo labeling summary rows were generated.\\n'');\n');
+    fprintf(fid, '    else\n');
+    fprintf(fid, '        dsNames = cellfun(@(row) strtok(row, '',''), summaryRows, ''UniformOutput'', false);\n');
+    fprintf(fid, '        [~, sortIdx] = sort(dsNames);\n');
+    fprintf(fid, '        fidSummary = fopen(summaryOutputFile, ''w'');\n');
+    fprintf(fid, '        if fidSummary == -1\n');
+    fprintf(fid, '            error(''Could not open summary file for writing: %%s'', summaryOutputFile);\n');
+    fprintf(fid, '        end\n');
+    fprintf(fid, '        fprintf(fidSummary, ''Dataset,FullDescription,TrialCount\\n'');\n');
+    fprintf(fid, '        for rowIdx = sortIdx\n');
+    fprintf(fid, '            fprintf(fidSummary, ''%%s\\n'', summaryRows{rowIdx});\n');
+    fprintf(fid, '        end\n');
+    fprintf(fid, '        fclose(fidSummary);\n');
+    fprintf(fid, '        append_eyesort_grand_totals(summaryOutputFile);\n');
+    fprintf(fid, '        fprintf(''\\nLabeling summary saved: %%s\\n'', summaryOutputFile);\n');
+    fprintf(fid, '    end\n');
+    fprintf(fid, 'end\n\n');
+
+    % --- Generated script: batch BDF from processed output directory ---
+    fprintf(fid, 'if generateBDF\n');
+    fprintf(fid, '    fprintf(''\\nGenerating BINLISTER BDF file...\\n'');\n');
+    fprintf(fid, '    generate_bdf_file(outputDir, bdfOutputFile);\n');
+    fprintf(fid, 'end\n\n');
+    fprintf(fid, 'fprintf(''\\nEyeSort script complete.\\n'');\n');
+
+    clear cleanupObj;
+    if isempty(scriptPathOut)
+        msgbox(sprintf('EyeSort script saved to:\n%s', scriptPath), 'EyeSort - Script Saved', 'help');
+    end
+end
+
+function scriptPathOut = parse_script_path_arg(varargin)
+    % Preserve old test-call shapes while removing user-facing scope choices.
+    scriptPathOut = '';
+    if nargin < 1
+        return;
+    end
+    firstArg = varargin{1};
+    if ischar(firstArg) || isstring(firstArg)
+        firstArgText = lower(char(firstArg));
+        if strcmp(firstArgText, 'session') || strcmp(firstArgText, 'dataset')
+            if nargin >= 2
+                scriptPathOut = varargin{2};
+            end
+            return;
+        end
+    end
+    scriptPathOut = firstArg;
+end
+
+function state = load_session_state()
+    % Prefer live base-workspace state; fall back to cached .mat from last session.
+    try
+        state = evalin('base', 'eyesort_session_state');
+        if isstruct(state)
+            return;
+        end
+    catch
+    end
+
+    statePath = fullfile(plugin_root(), 'cache', 'last_session_state.mat');
+    if exist(statePath, 'file')
+        loaded = load(statePath);
+        if isfield(loaded, 'state') && isstruct(loaded.state)
+            state = loaded.state;
+            return;
+        end
+    end
+
+    state = struct();
+end
+
+function state = fill_state_from_workspace(state)
+    % Backfill missing fields from EEG in base and default cache sidecar paths.
+    if ~isfield(state, 'inputFiles') || isempty(state.inputFiles)
+        try
+            EEG = evalin('base', 'EEG');
+            if isfield(EEG, 'filename') && ~isempty(EEG.filename)
+                state.inputFiles = {fullfile(EEG.filepath, EEG.filename)};
+                state.inputDir = EEG.filepath;
+            end
+        catch
+        end
+    end
+    if (~isfield(state, 'inputDir') || isempty(state.inputDir)) && isfield(state, 'inputFiles') && ~isempty(state.inputFiles)
+        state.inputDir = common_parent_directory(state.inputFiles);
+    end
+
+    if ~isfield(state, 'textIAConfigPath') || isempty(state.textIAConfigPath)
+        candidate = fullfile(plugin_root(), 'cache', 'last_text_ia_config.mat');
+        if exist(candidate, 'file')
+            state.textIAConfigPath = candidate;
+        end
+    end
+
+    if ~isfield(state, 'labelQueueConfigPath') || isempty(state.labelQueueConfigPath)
+        candidate = fullfile(plugin_root(), 'cache', 'last_label_queue.mat');
+        if exist(candidate, 'file')
+            state.labelQueueConfigPath = candidate;
+        end
+    end
+end
+
+function inputDir = get_input_dir(state)
+    % Return explicit inputDir, or infer a shared parent when all files match.
+    if isfield(state, 'inputDir') && ~isempty(state.inputDir)
+        inputDir = state.inputDir;
+        return;
+    end
+    if isfield(state, 'inputFiles') && ~isempty(state.inputFiles)
+        inputDir = common_parent_directory(state.inputFiles);
+        return;
+    end
+    inputDir = '';
+end
+
+function validate_session_state(state)
+    % Require Step 1 datasets and Step 2 Text IA config before script export.
+    if ~isfield(state, 'inputFiles') || isempty(state.inputFiles)
+        error('No EyeSort input dataset paths were captured. Run Step 1 before saving a script.');
+    end
+    inputDir = get_input_dir(state);
+    if isempty(inputDir)
+        error('No input dataset directory was captured. Run Step 1 before saving a processing script.');
+    end
+    if ~exist(inputDir, 'dir')
+        error('Captured input dataset directory does not exist: %s', inputDir);
+    end
+    if ~isfield(state, 'textIAConfigPath') || isempty(state.textIAConfigPath) || ~exist(state.textIAConfigPath, 'file')
+        error('No Step 2 Text IA configuration was found. Run Step 2 before saving a script.');
+    end
+end
+
+function inputFiles = get_input_files(state)
+    % Exact Step 1 file list, used as a commented reproducibility fallback.
+    inputFiles = state.inputFiles;
+    if ischar(inputFiles) || isstring(inputFiles)
+        inputFiles = cellstr(inputFiles);
+    end
+end
+
+function parentDir = common_parent_directory(inputFiles)
+    % Return the shared directory when all paths agree; otherwise the grandparent.
+    if ischar(inputFiles) || isstring(inputFiles)
+        inputFiles = cellstr(inputFiles);
+    end
+    parentDir = '';
+    if isempty(inputFiles)
+        return;
+    end
+    [parentDir, ~, ~] = fileparts(inputFiles{1});
+    for idx = 2:numel(inputFiles)
+        [candidateDir, ~, ~] = fileparts(inputFiles{idx});
+        if ~strcmp(parentDir, candidateDir)
+            % Mixed directories: fall back to parent of the first file's folder.
+            parentDir = fileparts(parentDir);
+            return;
+        end
+    end
+end
+
+function outputDir = get_output_dir(state, fallbackDir)
+    % Use Step 1 output directory when recorded; otherwise the script folder.
+    if isfield(state, 'outputDir') && ~isempty(state.outputDir)
+        outputDir = state.outputDir;
+    else
+        outputDir = fallbackDir;
+    end
+end
+
+function importColumns = get_import_columns(state)
+    % Step 3 column import list; empty when import was not run in this session.
+    if isfield(state, 'importColumns') && ~isempty(state.importColumns)
+        importColumns = state.importColumns;
+    else
+        importColumns = {};
+    end
+end
+
+function conflictResolution = get_conflict_resolution(state)
+    % Label conflict policy from Step 4; default replaces existing labels.
+    if isfield(state, 'conflictResolution') && ~isempty(state.conflictResolution)
+        conflictResolution = state.conflictResolution;
+    else
+        conflictResolution = 'yes';
+    end
+end
+
+function generateBDF = should_generate_bdf(state, labelQueuePath)
+    % Honor explicit Step 5 flag; otherwise enable BDF when a label queue exists.
+    if isfield(state, 'generateBDF') && ~isempty(state.generateBDF)
+        generateBDF = logical(state.generateBDF);
+    else
+        generateBDF = ~isempty(labelQueuePath);
+    end
+end
+
+function sidecarPath = copy_sidecar(sourcePath, targetDir, targetName)
+    % Copy a config .mat beside the script; skip copy when already in place.
+    if ~exist(sourcePath, 'file')
+        error('Required sidecar file not found: %s', sourcePath);
+    end
+    sidecarPath = fullfile(targetDir, targetName);
+    if ~strcmp(sourcePath, sidecarPath)
+        [copyOk, copyMsg] = copyfile(sourcePath, sidecarPath);
+        if ~copyOk
+            error('Could not copy sidecar file "%s" to "%s": %s', sourcePath, sidecarPath, copyMsg);
+        end
+    end
+end
+
+function localize_text_ia_files(textConfigPath, targetDir, scriptBaseName)
+    % Copy interest-area text files next to the script and update config paths.
+    loaded = load(textConfigPath);
+    if ~isfield(loaded, 'config') || ~isfield(loaded.config, 'txtFileList')
+        return;
+    end
+
+    config = loaded.config;
+    txtFiles = config.txtFileList;
+    wasCell = iscell(txtFiles);
+    if isstring(txtFiles)
+        txtFiles = cellstr(txtFiles);
+        wasCell = true;
+    end
+    if ~wasCell
+        txtFiles = {txtFiles};
+    end
+    if isempty(txtFiles)
+        error('Text IA configuration does not contain any interest area text files.');
+    end
+
+    copiedFiles = txtFiles;
+    for idx = 1:numel(txtFiles)
+        sourcePath = txtFiles{idx};
+        if isstring(sourcePath)
+            sourcePath = char(sourcePath);
+        end
+        if ~ischar(sourcePath) || isempty(sourcePath)
+            error('Text IA configuration contains an invalid interest area text file path at index %d.', idx);
+        end
+        if ~exist(sourcePath, 'file')
+            error('Interest area text file not found while saving EyeSort script: %s', sourcePath);
+        end
+        [~, sourceName, sourceExt] = fileparts(sourcePath);
+        % Single file: scriptBaseName_interest_areas.ext; multiple: indexed names.
+        if numel(txtFiles) == 1
+            targetName = sprintf('%s_interest_areas%s', scriptBaseName, sourceExt);
+        else
+            targetName = sprintf('%s_interest_areas_%02d_%s%s', scriptBaseName, idx, sourceName, sourceExt);
+        end
+        targetPath = fullfile(targetDir, targetName);
+        if ~strcmp(sourcePath, targetPath)
+            [copyOk, copyMsg] = copyfile(sourcePath, targetPath);
+            if ~copyOk
+                error('Could not copy interest area text file "%s" to "%s": %s', ...
+                    sourcePath, targetPath, copyMsg);
+            end
+        end
+        copiedFiles{idx} = targetPath;
+    end
+
+    % Persist rewritten paths so load_text_ia_config resolves local copies.
+    if wasCell
+        config.txtFileList = copiedFiles;
+    else
+        config.txtFileList = copiedFiles{1};
+    end
+    save(textConfigPath, 'config');
+end
+
+function write_cellstr_assignment(fid, varName, values)
+    % Emit a multi-line cellstr assignment with safely quoted string literals.
+    if ischar(values) || isstring(values)
+        values = cellstr(values);
+    end
+    if isempty(values)
+        fprintf(fid, '%s = {};\n', varName);
+        return;
+    end
+    fprintf(fid, '%s = { ...\n', varName);
+    for idx = 1:numel(values)
+        fprintf(fid, '    %s', matlab_literal(values{idx}));
+        if idx < numel(values)
+            fprintf(fid, '; ...\n');
+        else
+            fprintf(fid, '\n');
+        end
+    end
+    fprintf(fid, '};\n');
+end
+
+function write_commented_cellstr_assignment(fid, varName, values)
+    % Emit a commented cellstr assignment users can uncomment for exact replay.
+    if ischar(values) || isstring(values)
+        values = cellstr(values);
+    end
+    fprintf(fid, '%% %s = { ...\n', varName);
+    for idx = 1:numel(values)
+        fprintf(fid, '%%     %s', matlab_literal(values{idx}));
+        if idx < numel(values)
+            fprintf(fid, '; ...\n');
+        else
+            fprintf(fid, '\n');
+        end
+    end
+    fprintf(fid, '%% };\n');
+end
+
+function literal = matlab_literal(value)
+    % Quote a char/string for insertion into generated MATLAB source code.
+    if isstring(value)
+        value = char(value);
+    end
+    value = strrep(value, '''', '''''');
+    literal = ['''' value ''''];
+end
+
+function literal = logical_literal(value)
+    % Render a logical as lowercase 'true'/'false' for generated scripts.
+    if value
+        literal = 'true';
+    else
+        literal = 'false';
+    end
+end
+
+function root = plugin_root()
+    % EyeSort plugin root (parent of functions/).
+    root = fileparts(fileparts(mfilename('fullpath')));
+end

--- a/functions/update_eyesort_session_state.m
+++ b/functions/update_eyesort_session_state.m
@@ -1,0 +1,72 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+% EyeSort - Region-aware eye-tracking event labeling for EEGLAB
+% Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
+% Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function state = update_eyesort_session_state(varargin)
+    % Persist enough EyeSort GUI state to generate a GUI-free session script.
+
+    state = load_existing_state();
+
+    if mod(nargin, 2) ~= 0
+        error('update_eyesort_session_state requires name-value arguments.');
+    end
+
+    for idx = 1:2:nargin
+        name = varargin{idx};
+        value = varargin{idx + 1};
+        if ~ischar(name) && ~isstring(name)
+            error('Session state field names must be strings.');
+        end
+        state.(char(name)) = value;
+    end
+
+    state.updatedDate = datestr(now);
+
+    cacheFile = session_state_file();
+    cacheDir = fileparts(cacheFile);
+    if ~exist(cacheDir, 'dir')
+        mkdir(cacheDir);
+    end
+    save(cacheFile, 'state');
+    assignin('base', 'eyesort_session_state', state);
+end
+
+function state = load_existing_state()
+    try
+        state = evalin('base', 'eyesort_session_state');
+        if isstruct(state)
+            return;
+        end
+    catch
+    end
+
+    cacheFile = session_state_file();
+    if exist(cacheFile, 'file')
+        loaded = load(cacheFile);
+        if isfield(loaded, 'state') && isstruct(loaded.state)
+            state = loaded.state;
+            return;
+        end
+    end
+
+    state = struct();
+end
+
+function cacheFile = session_state_file()
+    pluginDir = fileparts(fileparts(mfilename('fullpath')));
+    cacheFile = fullfile(pluginDir, 'cache', 'last_session_state.mat');
+end

--- a/pop_functions/pop_convert_event_codes.m
+++ b/pop_functions/pop_convert_event_codes.m
@@ -35,6 +35,14 @@ function [EEG, com] = pop_convert_event_codes(EEG)
 
 com = '';
 
+% Menu callbacks invoke this function with no arguments, so EEG is never
+% created until it is explicitly assigned below. Initialize it here so
+% every return path (including batch mode and early validation errors)
+% leaves EEG as a valid output argument.
+if nargin < 1
+    EEG = [];
+end
+
 % Detect whether we should run in batch mode by looking for an output
 % directory left behind by pop_label_datasets.
 batchDir = '';
@@ -236,8 +244,22 @@ uiwait(hDlg);
 
         if batchMode
             stats = apply_batch(batchFiles, selectedFormat);
-            com = sprintf('%% pop_convert_event_codes batch: %d file(s) -> %s', ...
-                length(batchFiles), selectedFormat);
+            com = sprintf('%% pop_convert_event_codes batch: %d file(s) in %s -> %s format', ...
+                length(batchFiles), batchDir, selectedFormat);
+
+            % Reload a converted dataset into the workspace so downstream
+            % EEGLAB/EyeSort steps have a valid, up-to-date EEG to work with.
+            if stats.converted > 0 && ~isempty(stats.firstConvertedFile)
+                try
+                    EEG = pop_loadset(stats.firstConvertedFile);
+                    assignin('base', 'EEG', EEG);
+                catch ME
+                    warning('EyeSort:ConvertEventCodes', ...
+                        ['Datasets were converted and saved, but reloading %s into the ' ...
+                         'workspace failed: %s'], stats.firstConvertedFile, ME.message);
+                end
+            end
+
             msgbox(sprintf(['Event marker conversion complete.\n\nConverted: %d dataset(s)\n' ...
                 'Skipped not labeled: %d dataset(s)\nFailed: %d dataset(s)\n\nFormat: %s'], ...
                 stats.converted, stats.skipped, stats.failed, selectedFormat), ...
@@ -259,7 +281,7 @@ end
 %% Apply conversion to a list of dataset files, saving each in place.
 function stats = apply_batch(files, fmt)
     nFiles = length(files);
-    stats = struct('converted', 0, 'skipped', 0, 'failed', 0);
+    stats = struct('converted', 0, 'skipped', 0, 'failed', 0, 'firstConvertedFile', '');
     fprintf('Converting event codes in %d dataset(s) to format ''%s''...\n', nFiles, fmt);
     h = waitbar(0, 'Converting event codes...', 'Name', 'Convert Event Codes');
     cleanup = onCleanup(@() safe_delete(h));
@@ -285,6 +307,9 @@ function stats = apply_batch(files, fmt)
             pop_saveset(tmp, 'filename', fname, 'filepath', folder, 'savemode', 'twofiles');
             fprintf('  Converted %d/%d: %s\n', i, nFiles, fname);
             stats.converted = stats.converted + 1;
+            if isempty(stats.firstConvertedFile)
+                stats.firstConvertedFile = files{i};
+            end
         catch ME
             warning('Failed to convert %s: %s', fname, ME.message);
             stats.failed = stats.failed + 1;

--- a/pop_functions/pop_generate_bdf.m
+++ b/pop_functions/pop_generate_bdf.m
@@ -113,6 +113,7 @@ function [EEG, com] = pop_generate_bdf(EEG)
             % This allows it to find ALLEEG if available, or fall back to EEG
             % The function will handle its own file dialog
             generate_bdf_file();
+            update_eyesort_session_state('generateBDF', true);
             
             % Create command string for history
             com = sprintf('EEG = pop_generate_bdf(EEG);');

--- a/pop_functions/pop_import_ia_columns.m
+++ b/pop_functions/pop_import_ia_columns.m
@@ -99,8 +99,10 @@ function [EEG, com] = pop_import_ia_columns(EEG)
     cachedItemCol = '';
     cachedRegionNames = {};
 
-    % Get region names from current EEG
-    if batch_mode
+    % Get region names from the currently loaded reference dataset when possible.
+    if isfield(EEG, 'region_names')
+        cachedRegionNames = EEG.region_names;
+    elseif batch_mode
         try
             tempEEG = pop_loadset('filename', batchFilePaths{1});
             if isfield(tempEEG, 'region_names')
@@ -108,10 +110,6 @@ function [EEG, com] = pop_import_ia_columns(EEG)
             end
             clear tempEEG;
         catch
-        end
-    else
-        if isfield(EEG, 'region_names')
-            cachedRegionNames = EEG.region_names;
         end
     end
 
@@ -378,6 +376,12 @@ function [EEG, com] = pop_import_ia_columns(EEG)
         catch
         end
 
+        if modifiedCount > 0
+            update_eyesort_session_state('importFilePath', filePath, ...
+                'importCondColName', condColName, 'importItemColName', itemColName, ...
+                'importColumns', selectedCols);
+        end
+
         if modifiedCount == 0
             if ~hasImportErrors
                 errordlg('No datasets were modified. Ensure Step 2 has been run on the loaded datasets.', 'EyeSort - Import Complete');
@@ -450,6 +454,11 @@ function [EEG, com] = pop_import_ia_columns(EEG)
         end
 
         delete(h);
+        if successCount > 0
+            update_eyesort_session_state('importFilePath', filePath, ...
+                'importCondColName', condColName, 'importItemColName', itemColName, ...
+                'importColumns', selectedCols);
+        end
         if successCount == 0
             if ~hasImportErrors
                 errordlg('No datasets were modified. Ensure Step 2 has been run on the batch datasets.', 'EyeSort - Import Complete');

--- a/pop_functions/pop_label_datasets.m
+++ b/pop_functions/pop_label_datasets.m
@@ -812,6 +812,9 @@ function [EEG, com] = pop_label_datasets(EEG)
         % Auto-save the queue so it can be reloaded next session
         try
             save_label_config(pending_labels, 'last_label_queue.mat');
+            update_eyesort_session_state('labelQueueConfigPath', ...
+                fullfile(fileparts(fileparts(mfilename('fullpath'))), 'cache', 'last_label_queue.mat'), ...
+                'conflictResolution', saved_conflict_resolution);
         catch
             fprintf('Note: Could not auto-save label queue.\n');
         end
@@ -831,11 +834,7 @@ function [EEG, com] = pop_label_datasets(EEG)
 
                 % Write per-full_description CSV summary
                 if isfield(EEG, 'event') && isfield(EEG.event, 'bdf_full_description')
-                    session_idx = 1;
-                    while exist(fullfile(outputDir_single, sprintf('eyesort_labeling_summary_%03d.csv', session_idx)), 'file')
-                        session_idx = session_idx + 1;
-                    end
-                    csv_path = fullfile(outputDir_single, sprintf('eyesort_labeling_summary_%03d.csv', session_idx));
+                    csv_path = next_available_eyesort_summary_file(outputDir_single);
                     allFD = {EEG.event.bdf_full_description};
                     allFD = allFD(~cellfun(@isempty, allFD));
                     uniqueFD = unique(allFD);
@@ -846,7 +845,7 @@ function [EEG, com] = pop_label_datasets(EEG)
                             fprintf(fid, '%s,%s,%d\n', name, uniqueFD{ui}, sum(strcmp(allFD, uniqueFD{ui})));
                         end
                         fclose(fid);
-                        append_grand_totals(csv_path);
+                        append_eyesort_grand_totals(csv_path);
                         fprintf('Summary saved to: %s\n', csv_path);
                     end
                 end
@@ -967,11 +966,7 @@ function [EEG, com] = pop_label_datasets(EEG)
         nLabels = length(pending_labels);
 
         % Generate a unique summary filename for this session
-        session_idx = 1;
-        while exist(fullfile(outputDir, sprintf('eyesort_labeling_summary_%03d.csv', session_idx)), 'file')
-            session_idx = session_idx + 1;
-        end
-        session_summary_file = fullfile(outputDir, sprintf('eyesort_labeling_summary_%03d.csv', session_idx));
+        session_summary_file = next_available_eyesort_summary_file(outputDir);
 
         % saved_conflict_resolution threads the user's "remember" choice across
         % all labels and all datasets so the conflict dialog never repeats.
@@ -1077,11 +1072,14 @@ function [EEG, com] = pop_label_datasets(EEG)
                 fclose(fid);
             end
         end
-        append_grand_totals(session_summary_file);
+        append_eyesort_grand_totals(session_summary_file);
 
         % Auto-save the queue for next session
         try
             save_label_config(pending_labels, 'last_label_queue.mat');
+            update_eyesort_session_state('labelQueueConfigPath', ...
+                fullfile(fileparts(fileparts(mfilename('fullpath'))), 'cache', 'last_label_queue.mat'), ...
+                'conflictResolution', saved_conflict_resolution);
         catch
             fprintf('Note: Could not auto-save label queue.\n');
         end
@@ -1204,41 +1202,6 @@ function [EEG, com] = pop_label_datasets(EEG)
             label_params{end+1} = 'labelDescription';
             label_params{end+1} = config.labelDescription;
         end
-    end
-
-    % Append grand-total rows (sum across all datasets) to an existing CSV
-    function append_grand_totals(csv_path)
-        fid = fopen(csv_path, 'r');
-        if fid == -1, return; end
-        header = fgetl(fid);
-        rows = {};
-        while ~feof(fid)
-            line = strtrim(fgetl(fid));
-            if ~isempty(line), rows{end+1} = line; end
-        end
-        fclose(fid);
-        if isempty(rows), return; end
-
-        fdMap = containers.Map('KeyType','char','ValueType','double');
-        for ri = 1:length(rows)
-            parts = strsplit(rows{ri}, ',');
-            if length(parts) >= 3
-                key = strjoin(parts(2:end-1), ',');
-                val = str2double(parts{end});
-                if isKey(fdMap, key)
-                    fdMap(key) = fdMap(key) + val;
-                else
-                    fdMap(key) = val;
-                end
-            end
-        end
-
-        fid = fopen(csv_path, 'a');
-        if fid == -1, return; end
-        for k = keys(fdMap)
-            fprintf(fid, 'TOTAL,%s,%d\n', k{1}, fdMap(k{1}));
-        end
-        fclose(fid);
     end
 
 end

--- a/pop_functions/pop_load_datasets.m
+++ b/pop_functions/pop_load_datasets.m
@@ -122,6 +122,7 @@ function [EEG, com] = pop_load_datasets(EEG)
 
     % Variables to store directory paths
     outputDir = '';
+    selectedDatasetDir = '';
 
 %% ----------------------- NestedCallback Functions --------------------------
 
@@ -152,6 +153,7 @@ function [EEG, com] = pop_load_datasets(EEG)
         end
         
         selected_datasets = [selected_datasets, new_paths];
+        selectedDatasetDir = path;
 
         % Update the listbox
         set(findobj(hFig, 'tag', 'datasetList'), ...
@@ -185,6 +187,7 @@ function [EEG, com] = pop_load_datasets(EEG)
         
         % Replace selected_datasets with directory contents
         selected_datasets = new_paths;
+        selectedDatasetDir = dir_path;
         
         % Update the listbox
         set(findobj(hFig, 'tag', 'datasetList'), ...
@@ -257,6 +260,15 @@ function [EEG, com] = pop_load_datasets(EEG)
         % Determine mode based on number of datasets
         num_datasets = numel(selected_datasets);
 
+        datasetDirs = cellfun(@(p) fileparts(p), selected_datasets, 'UniformOutput', false);
+        if numel(unique(datasetDirs)) > 1
+            errordlg(['All selected datasets must come from the same directory when saving a session script.', ...
+                char(10), 'Use Browse Directory for batch processing, or select files from one folder only.'], ...
+                'EyeSort - Mixed Dataset Directories');
+            return;
+        end
+        selectedDatasetDir = datasetDirs{1};
+
         % Retrieve ALLEEG, CURRENTSET from base if they exist
         try
             ALLEEG    = evalin('base', 'ALLEEG'); 
@@ -281,6 +293,9 @@ function [EEG, com] = pop_load_datasets(EEG)
             assignin('base', 'eyesort_batch_filenames', batchFileNames);
             assignin('base', 'eyesort_batch_output_dir', outputDir);
             assignin('base', 'eyesort_batch_mode', true);
+            update_eyesort_session_state('inputFiles', batchFilePaths, ...
+                'inputDir', selectedDatasetDir, 'batchMode', true, 'outputDir', outputDir, 'importColumns', {}, ...
+                'labelQueueConfigPath', '', 'conflictResolution', '');
             
             % Load only the first dataset for GUI display
             try
@@ -297,6 +312,7 @@ function [EEG, com] = pop_load_datasets(EEG)
             
             % Build command string for history
             com = sprintf('EEG = pop_load_datasets(EEG); %% Prepared %d datasets for batch processing', num_datasets);
+            record_eyesort_history(com);
             
             % Calculate approximate memory usage
             est_memory_mb = num_datasets * 200;
@@ -323,6 +339,9 @@ function [EEG, com] = pop_load_datasets(EEG)
             
             % Store output directory (required for auto-save after labeling)
             assignin('base', 'eyesort_single_output_dir', outputDir);
+            update_eyesort_session_state('inputFiles', selected_datasets, ...
+                'inputDir', selectedDatasetDir, 'batchMode', false, 'outputDir', outputDir, 'importColumns', {}, ...
+                'labelQueueConfigPath', '', 'conflictResolution', '');
             
             % Load the single dataset into ALLEEG
             dataset_path = selected_datasets{1};
@@ -358,6 +377,7 @@ function [EEG, com] = pop_load_datasets(EEG)
 
                 % Build command string for history
                 com = 'EEG = pop_load_datasets(EEG);';
+                record_eyesort_history(com, EEG);
 
                 % Show success message
                 msgbox(sprintf(['Success: Dataset loaded into EEGLAB.\n\n', ...

--- a/pop_functions/pop_load_text_ia.m
+++ b/pop_functions/pop_load_text_ia.m
@@ -875,6 +875,8 @@ function [EEG, com] = pop_load_text_ia(EEG)
                     config = collect_gui_settings();
                     if ~isempty(config)
                         save_text_ia_config(config, 'last_text_ia_config.mat');
+                        update_eyesort_session_state('textIAConfigPath', ...
+                            fullfile(fileparts(fileparts(mfilename('fullpath'))), 'cache', 'last_text_ia_config.mat'));
                     end
                 catch
                     % Don't fail the main process if auto-save fails
@@ -901,6 +903,10 @@ function [EEG, com] = pop_load_text_ia(EEG)
                 end
                 h_msg = msgbox(sprintf('Text IA processing complete!\n\nProcessed: %d datasets\nFailed: %d datasets\n\nNow proceed to step 3 (Eye-Tracking Event Labeling) to apply labels.%s', processed_count, failed_count, batchNote), 'Batch Processing Complete');
                 waitfor(h_msg); % Wait for user to close the message box
+                
+                % Update command string for history
+                com = sprintf('EEG = pop_load_text_ia(EEG); %% Batch Text IA processing completed for %d datasets', processed_count);
+                record_eyesort_history(com);
                 
                 % Close GUI after batch processing completion
                 close(hFig);
@@ -979,6 +985,8 @@ function [EEG, com] = pop_load_text_ia(EEG)
                 config = collect_gui_settings();
                 if ~isempty(config)
                     save_text_ia_config(config, 'last_text_ia_config.mat');
+                    update_eyesort_session_state('textIAConfigPath', ...
+                        fullfile(fileparts(fileparts(mfilename('fullpath'))), 'cache', 'last_text_ia_config.mat'));
                 end
             catch
                 % Don't fail the main process if auto-save fails
@@ -986,8 +994,9 @@ function [EEG, com] = pop_load_text_ia(EEG)
             end
 
             % Update command string for history
-            com = sprintf('EEG = pop_loadTextIA(EEG); %% file=%s offset=%g px=%g',...
+            com = sprintf('EEG = pop_load_text_ia(EEG); %% file=%s offset=%g px=%g',...
                      txtFilePath, offset, pxPerChar);
+            record_eyesort_history(com, processedEEG);
 
             % Close GUI
             close(hFig);


### PR DESCRIPTION
Summary:
Adds session history capture and script export so a GUI EyeSort run can be saved as a portable `.m` file that replays the pipeline without reopening dialogs. Also fixes batch event-code conversion edge cases and bumps EyeSort to v0.6.

- Added **History Scripts → Save processing history script** under the EyeSort menu
- Added `save_eyesort_session_script`, `update_eyesort_session_state`, and `record_eyesort_history` to capture pipeline settings and EEGLAB history during Steps 1–5
- Generated scripts bundle portable sidecars (Text IA config, label queue, interest-area text files) and default to scanning `inputDir` for `*.set` files
- Added `next_available_eyesort_summary_file` and `append_eyesort_grand_totals` helpers shared by GUI batch labeling and generated scripts
- Pushed session state updates through `pop_load_datasets`, `pop_load_text_ia`, `pop_import_ia_columns`, `pop_label_datasets`, and `pop_generate_bdf`
- Added non-interactive directory mode to `generate_bdf_file` for scripted processing
- Fixed `convert_config_to_params` fixation option mapping and `labelDescription` propagation for scripted label queue processing
- Reused in-memory `EEG.region_names` in batch import to avoid redundant loads
- **fix(convert-event-codes):** initialize `EEG` when menu callbacks call `pop_convert_event_codes` with no inputs; reload first converted dataset after batch conversion; improve batch history string with source directory