### PR TITLE
Change log:

### DIFF
--- a/functions/batch_label_utils.m
+++ b/functions/batch_label_utils.m
@@ -45,11 +45,11 @@ processed_count = 0;
 failed_files = {};
 
 % Create progress bar
-h = waitbar(0, 'Applying labels to all datasets...', 'Name', 'Batch Labeling');
+h = eyesort_waitbar(0, 'Applying labels to all datasets...', 'Name', 'Batch Labeling');
 
 try
     for i = 1:length(batchFilePaths)
-        waitbar(i/length(batchFilePaths), h, sprintf('Labeling dataset %d of %d: %s', i, length(batchFilePaths), batchFilenames{i}));
+        eyesort_waitbar(i/length(batchFilePaths), h, sprintf('Labeling dataset %d of %d: %s', i, length(batchFilePaths), batchFilenames{i}));
         
         try
             % Load dataset from file

--- a/functions/expand_trigger_ranges.m
+++ b/functions/expand_trigger_ranges.m
@@ -19,7 +19,7 @@
 % Author: Brandon Snyder
 
 function expandedTriggers = expand_trigger_ranges(triggerInput)
-%EXPAND_TRIGGER_RANGES - Expand trigger ranges like "S1:S112" into individual triggers
+% EXPAND_TRIGGER_RANGES - Expand trigger ranges like "S1:S112" into individual triggers
 %
 % This function handles the complex logic of expanding trigger ranges while
 % maintaining backward compatibility. It's the only duplication worth centralizing.

--- a/functions/eyesort_waitbar.m
+++ b/functions/eyesort_waitbar.m
@@ -1,0 +1,26 @@
+% SPDX-License-Identifier: GPL-3.0-or-later
+function h = eyesort_waitbar(varargin)
+% EYESORT_WAITBAR Waitbar with literal text (no TeX).
+%   Filenames like ES02_processed.set contain underscores; MATLAB's default
+%   TeX interpreter treats "_" as subscript, which misrenders waitbar text.
+%
+%   Usage matches waitbar:
+%     h = eyesort_waitbar(x, msg, 'Name', name)
+%     eyesort_waitbar(x, h, msg)
+
+    h = waitbar(varargin{:});
+    disable_tex(h);
+end
+
+function disable_tex(h)
+    if ~ishandle(h)
+        return;
+    end
+    try
+        txt = findall(h, 'Type', 'text');
+        if ~isempty(txt)
+            set(txt, 'Interpreter', 'none');
+        end
+    catch
+    end
+end

--- a/functions/format_diagnostics.m
+++ b/functions/format_diagnostics.m
@@ -4,7 +4,7 @@
 % Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
 
 function message = format_diagnostics(diagnostics, titleText)
-%FORMAT_DIAGNOSTICS Convert diagnostic structs into readable text.
+% FORMAT_DIAGNOSTICS Convert diagnostic structs into readable text.
 
     if nargin < 2 || isempty(titleText)
         titleText = 'EyeSort input diagnostics';

--- a/functions/label_datasets_core.m
+++ b/functions/label_datasets_core.m
@@ -935,15 +935,14 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                 [labeledEEG.event.bdf_label_description] = deal('');
                 [labeledEEG.event.bdf_full_description] = deal('');
             end
-            if ~isfield(labeledEEG.event, 'current_word_text')
-                [labeledEEG.event.current_word_text] = deal('');
-            end
             bdf_fields_initialized = true;
         end
         
-        % Resolve the actual word text from the positional current_word index
+        % Prefer current_word_text from trial_labeling; fall back to resolving from current_word
         wordText = '';
-        if isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
+        if isfield(evt, 'current_word_text') && ischar(evt.current_word_text) && ~isempty(evt.current_word_text)
+            wordText = evt.current_word_text;
+        elseif isfield(evt, 'current_word') && ischar(evt.current_word) && ~isempty(evt.current_word)
             try
                 [regionNum, wordNum] = parse_word_region(evt.current_word);
                 wordsField = sprintf('region%d_words', regionNum);
@@ -955,8 +954,8 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                 end
             catch
             end
+            labeledEEG.event(mm).current_word_text = wordText;
         end
-        labeledEEG.event(mm).current_word_text = wordText;
         
         % Resolve condition description (needed for BDF fields and text formats)
         conditionDesc = '';
@@ -1107,10 +1106,12 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                     end
                 end
                 
-                % Resolve word text for conflict events
+                % Prefer current_word_text from trial_labeling; fall back to resolving
                 cEvt = labeledEEG.event(evt_idx);
                 cWordText = '';
-                if isfield(cEvt, 'current_word') && ischar(cEvt.current_word) && ~isempty(cEvt.current_word)
+                if isfield(cEvt, 'current_word_text') && ischar(cEvt.current_word_text) && ~isempty(cEvt.current_word_text)
+                    cWordText = cEvt.current_word_text;
+                elseif isfield(cEvt, 'current_word') && ischar(cEvt.current_word) && ~isempty(cEvt.current_word)
                     try
                         [rn, wn] = parse_word_region(cEvt.current_word);
                         wf = sprintf('region%d_words', rn);
@@ -1122,8 +1123,8 @@ function [labeledEEG, chosenConflictResolution] = label_dataset_internal(EEG, co
                         end
                     catch
                     end
+                    labeledEEG.event(evt_idx).current_word_text = cWordText;
                 end
-                labeledEEG.event(evt_idx).current_word_text = cWordText;
                 
                 % Set type based on eventFormat
                 switch eventFormat

--- a/functions/match_trigger_list.m
+++ b/functions/match_trigger_list.m
@@ -3,7 +3,7 @@
 % Copyright (C) 2025 Eye Movements & Cognition Lab (USF)
 % Copyright (C) 2025 Brandon Snyder, Sara Milligan, Elizabeth Schotter
 
-function summary = match_trigger_list(eventTypes, triggers)
+function summary = match_trigger_list(eventTypes, triggers, eventNorm, eventNum)
 %MATCH_TRIGGER_LIST Count event matches for user trigger inputs.
 
     if nargin < 2
@@ -12,32 +12,42 @@ function summary = match_trigger_list(eventTypes, triggers)
     if ~iscell(triggers)
         triggers = {triggers};
     end
+    if nargin < 3 || isempty(eventNorm) || nargin < 4 || isempty(eventNum)
+        [eventNorm, eventNum] = precompute_event_features(eventTypes);
+    end
 
     nTriggers = length(triggers);
     perTrigger = zeros(1, nTriggers);
     exactCounts = zeros(1, nTriggers);
     numericCounts = zeros(1, nTriggers);
-    matchedEventMask = false(1, length(eventTypes));
     missingTriggers = {};
+    triggerNorms = cell(1, nTriggers);
+    triggerNums = cell(1, nTriggers);
+    triggerIsNumberOnly = false(1, nTriggers);
+    [exactCountMap, numericCountMap] = build_count_maps(eventNorm, eventNum);
 
     for iTrig = 1:nTriggers
         trig = triggers{iTrig};
-        for iEvt = 1:length(eventTypes)
-            [matched, mode] = trigger_match(eventTypes{iEvt}, trig);
-            if matched
-                perTrigger(iTrig) = perTrigger(iTrig) + 1;
-                matchedEventMask(iEvt) = true;
-                if strcmp(mode, 'exact')
-                    exactCounts(iTrig) = exactCounts(iTrig) + 1;
-                elseif strcmp(mode, 'numeric')
-                    numericCounts(iTrig) = numericCounts(iTrig) + 1;
-                end
-            end
+        triggerNorms{iTrig} = normalize_trigger_value(trig);
+        if isempty(triggerNorms{iTrig})
+            continue;
         end
+
+        exactCounts(iTrig) = lookup_count(exactCountMap, triggerNorms{iTrig});
+        triggerIsNumberOnly(iTrig) = ~isempty(regexp(triggerNorms{iTrig}, '^\d+$', 'once'));
+        if triggerIsNumberOnly(iTrig)
+            triggerNums{iTrig} = regexp(triggerNorms{iTrig}, '\d+', 'match', 'once');
+            numericCounts(iTrig) = lookup_count(numericCountMap, triggerNums{iTrig}) - exactCounts(iTrig);
+            numericCounts(iTrig) = max(numericCounts(iTrig), 0);
+        end
+
+        perTrigger(iTrig) = exactCounts(iTrig) + numericCounts(iTrig);
         if perTrigger(iTrig) == 0
             missingTriggers{end+1} = trigger_to_char(trig); %#ok<AGROW>
         end
     end
+
+    matchedEventMask = build_matched_event_mask(eventNorm, eventNum, triggerNorms, triggerNums, triggerIsNumberOnly);
 
     summary = struct();
     summary.triggers = triggers;
@@ -48,6 +58,67 @@ function summary = match_trigger_list(eventTypes, triggers)
     summary.rawMatchCount = sum(perTrigger);
     summary.missingTriggers = missingTriggers;
     summary.matchedEventIndices = find(matchedEventMask);
+    summary.numericMatchedEventCount = sum(matchedEventMask & ~cellfun('isempty', eventNum));
+end
+
+function [eventNorm, eventNum] = precompute_event_features(eventTypes)
+    eventNorm = cell(1, length(eventTypes));
+    eventNum = cell(1, length(eventTypes));
+    for iEvt = 1:length(eventTypes)
+        eventNorm{iEvt} = normalize_trigger_value(eventTypes{iEvt});
+        eventNum{iEvt} = regexp(eventNorm{iEvt}, '\d+', 'match', 'once');
+        if isempty(eventNum{iEvt})
+            eventNum{iEvt} = '';
+        end
+    end
+end
+
+function [exactCountMap, numericCountMap] = build_count_maps(eventNorm, eventNum)
+    exactCountMap = containers.Map('KeyType', 'char', 'ValueType', 'double');
+    numericCountMap = containers.Map('KeyType', 'char', 'ValueType', 'double');
+    for iEvt = 1:length(eventNorm)
+        exactCountMap = increment_count(exactCountMap, eventNorm{iEvt});
+        numericCountMap = increment_count(numericCountMap, eventNum{iEvt});
+    end
+end
+
+function countMap = increment_count(countMap, key)
+    if isempty(key)
+        return;
+    end
+    if isKey(countMap, key)
+        countMap(key) = countMap(key) + 1;
+    else
+        countMap(key) = 1;
+    end
+end
+
+function count = lookup_count(countMap, key)
+    count = 0;
+    if isempty(key)
+        return;
+    end
+    if isKey(countMap, key)
+        count = countMap(key);
+    end
+end
+
+function matchedEventMask = build_matched_event_mask(eventNorm, eventNum, triggerNorms, triggerNums, triggerIsNumberOnly)
+    matchedEventMask = false(1, length(eventNorm));
+
+    exactTriggerMask = ~cellfun('isempty', triggerNorms);
+    if any(exactTriggerMask)
+        matchedEventMask = matchedEventMask | ismember(eventNorm, unique(triggerNorms(exactTriggerMask)));
+    end
+
+    numericTriggerMask = triggerIsNumberOnly & ~cellfun('isempty', triggerNums);
+    if any(numericTriggerMask)
+        matchedEventMask = matchedEventMask | ismember(eventNum, unique(triggerNums(numericTriggerMask)));
+    end
+end
+
+function out = normalize_trigger_value(value)
+    out = strrep(strtrim(value_to_char(value)), ' ', '');
 end
 
 function out = trigger_to_char(value)

--- a/functions/trial_labeling.m
+++ b/functions/trial_labeling.m
@@ -93,6 +93,7 @@ function EEG = trial_labeling(EEG, startCode, endCode, conditionTriggers, itemTr
     [EEG.event.fixation_in_pass] = deal(0);           % which fixation in the current pass (1st, 2nd, etc.)
     [EEG.event.is_last_in_pass] = deal(false);        % pre-computed flag for last fixation in pass
     [EEG.event.current_word] = deal('');
+    [EEG.event.current_word_text] = deal('');
     [EEG.event.previous_word] = deal('');
     [EEG.event.is_first_pass_region] = deal(false);
     [EEG.event.is_first_pass_word] = deal(false);
@@ -217,15 +218,25 @@ function EEG = trial_labeling(EEG, startCode, endCode, conditionTriggers, itemTr
                         EEG.event(iEvt).current_word = currentWord;
                         EEG.event(iEvt).previous_word = previousWord;
                         
+                        % Parse current word into region and word number; resolve word text
+                        [curr_region, curr_word_num] = parse_word_region(currentWord);
+                        try
+                            wordsField = sprintf('region%d_words', curr_region);
+                            if isfield(EEG.event(iEvt), wordsField) && ~isempty(EEG.event(iEvt).(wordsField))
+                                words = EEG.event(iEvt).(wordsField);
+                                if iscell(words) && curr_word_num <= length(words)
+                                    EEG.event(iEvt).current_word_text = strtrim(words{curr_word_num});
+                                end
+                            end
+                        catch
+                        end
+                        
                         % Update word fixation counts
                         if ~isKey(wordFixationCounts, currentWord)
                             wordFixationCounts(currentWord) = 1;
                         else
                             wordFixationCounts(currentWord) = wordFixationCounts(currentWord) + 1;
                         end
-                        
-                        % Parse current word into region and word number
-                        [curr_region, curr_word_num] = parse_word_region(currentWord);
                         
                         % Update first-pass word information
                         % A word is only first-pass if:

--- a/functions/validate_triggers.m
+++ b/functions/validate_triggers.m
@@ -15,14 +15,15 @@ function [diagnostics, summary] = validate_triggers(EEG, startCode, endCode, con
 
     diagnostics = empty_diagnostics();
     eventTypes = event_type_strings(EEG);
+    [eventNorm, eventNum] = precompute_event_features(eventTypes);
 
     summary = struct();
     summary.eventCount = length(eventTypes);
     summary.eventExamples = event_examples(eventTypes, 10);
-    summary.start = match_trigger_list(eventTypes, {startCode});
-    summary.end = match_trigger_list(eventTypes, {endCode});
-    summary.condition = match_trigger_list(eventTypes, conditionTriggers);
-    summary.item = match_trigger_list(eventTypes, itemTriggers);
+    summary.start = match_trigger_list(eventTypes, {startCode}, eventNorm, eventNum);
+    summary.end = match_trigger_list(eventTypes, {endCode}, eventNorm, eventNum);
+    summary.condition = match_trigger_list(eventTypes, conditionTriggers, eventNorm, eventNum);
+    summary.item = match_trigger_list(eventTypes, itemTriggers, eventNorm, eventNum);
     summary.sentenceStart = [];
     summary.sentenceEnd = [];
 
@@ -49,7 +50,7 @@ function [diagnostics, summary] = validate_triggers(EEG, startCode, endCode, con
         diagnostics(end+1) = make_diag('error', 'Condition Triggers', 'conditionTriggers', join_triggers(conditionTriggers), ...
             'No EEG events matched any condition trigger. Condition/item keys cannot be created.', ...
             sprintf('Check the condition trigger text, prefix, and numbers against EEG.event.type. Examples: %s', strjoin(summary.eventExamples, ', ')));
-    elseif count_numeric_matched_events(eventTypes, conditionTriggers) == 0
+    elseif summary.condition.numericMatchedEventCount == 0
         diagnostics(end+1) = make_diag('error', 'Condition Triggers', 'conditionTriggers', join_triggers(conditionTriggers), ...
             'Condition triggers matched EEG events, but no matched condition event contained a numeric value for the IA-file key.', ...
             'Use condition trigger events that include the numeric condition code used by the IA file, or update EyeSort before using nonnumeric condition keys.');
@@ -63,7 +64,7 @@ function [diagnostics, summary] = validate_triggers(EEG, startCode, endCode, con
         diagnostics(end+1) = make_diag('error', 'Item Triggers', 'itemTriggers', join_triggers(itemTriggers), ...
             'No EEG events matched any item trigger. Condition/item keys cannot be created.', ...
             sprintf('Check the item trigger text, prefix, and numbers against EEG.event.type. Examples: %s', strjoin(summary.eventExamples, ', ')));
-    elseif count_numeric_matched_events(eventTypes, itemTriggers) == 0
+    elseif summary.item.numericMatchedEventCount == 0
         diagnostics(end+1) = make_diag('error', 'Item Triggers', 'itemTriggers', join_triggers(itemTriggers), ...
             'Item triggers matched EEG events, but no matched item event contained a numeric value for the IA-file key.', ...
             'Use item trigger events that include the numeric item code used by the IA file, or update EyeSort before using nonnumeric item keys.');
@@ -75,8 +76,8 @@ function [diagnostics, summary] = validate_triggers(EEG, startCode, endCode, con
 
     useSentenceCodes = ~isempty(strtrim(trigger_to_char(sentenceStartCode))) && ~isempty(strtrim(trigger_to_char(sentenceEndCode)));
     if useSentenceCodes
-        summary.sentenceStart = match_trigger_list(eventTypes, {sentenceStartCode});
-        summary.sentenceEnd = match_trigger_list(eventTypes, {sentenceEndCode});
+        summary.sentenceStart = match_trigger_list(eventTypes, {sentenceStartCode}, eventNorm, eventNum);
+        summary.sentenceEnd = match_trigger_list(eventTypes, {sentenceEndCode}, eventNorm, eventNum);
         if summary.sentenceStart.totalMatches == 0
             diagnostics(end+1) = make_diag('error', 'Stimulus Start Code', 'sentenceStartCode', trigger_to_char(sentenceStartCode), ...
                 'No EEG events matched the stimulus start code, so the requested eye-event time window cannot open.', ...
@@ -90,18 +91,14 @@ function [diagnostics, summary] = validate_triggers(EEG, startCode, endCode, con
     end
 end
 
-function count = count_numeric_matched_events(eventTypes, triggers)
-    if ~iscell(triggers)
-        triggers = {triggers};
-    end
-    count = 0;
+function [eventNorm, eventNum] = precompute_event_features(eventTypes)
+    eventNorm = cell(1, length(eventTypes));
+    eventNum = cell(1, length(eventTypes));
     for iEvt = 1:length(eventTypes)
-        for iTrig = 1:length(triggers)
-            if trigger_match(eventTypes{iEvt}, triggers{iTrig}) && ...
-                    ~isempty(regexp(strrep(eventTypes{iEvt}, ' ', ''), '\d+', 'once'))
-                count = count + 1;
-                break;
-            end
+        eventNorm{iEvt} = strrep(strtrim(value_to_char(eventTypes{iEvt})), ' ', '');
+        eventNum{iEvt} = regexp(eventNorm{iEvt}, '\d+', 'match', 'once');
+        if isempty(eventNum{iEvt})
+            eventNum{iEvt} = '';
         end
     end
 end

--- a/pop_functions/pop_convert_event_codes.m
+++ b/pop_functions/pop_convert_event_codes.m
@@ -296,14 +296,14 @@ function stats = apply_batch(files, fmt)
     nFiles = length(files);
     stats = struct('converted', 0, 'skipped', 0, 'failed', 0, 'firstConvertedFile', '');
     fprintf('Converting event codes in %d dataset(s) to format ''%s''...\n', nFiles, fmt);
-    h = waitbar(0, 'Converting event codes...', 'Name', 'Convert Event Codes');
+    h = eyesort_waitbar(0, 'Converting event codes...', 'Name', 'Convert Event Codes');
     cleanup = onCleanup(@() safe_delete(h));
 
     for i = 1:nFiles
         [folder, name, ext] = fileparts(files{i});
         fname = [name ext];
         try
-            waitbar((i-1)/nFiles, h, sprintf('Loading %s...', fname));
+            eyesort_waitbar((i-1)/nFiles, h, sprintf('Loading %s...', fname));
             tmp = pop_loadset('filename', fname, 'filepath', folder);
 
             if ~isfield(tmp, 'event') || isempty(tmp.event) || ...
@@ -313,11 +313,11 @@ function stats = apply_batch(files, fmt)
                 continue;
             end
 
-            waitbar((i-0.5)/nFiles, h, sprintf('Converting %s...', fname));
+            eyesort_waitbar((i-0.5)/nFiles, h, sprintf('Converting %s...', fname));
             tmp = convert_event_codes(tmp, fmt);
             tmp = eeg_checkset(tmp, 'eventconsistency');
 
-            waitbar((i-0.25)/nFiles, h, sprintf('Saving %s...', fname));
+            eyesort_waitbar((i-0.25)/nFiles, h, sprintf('Saving %s...', fname));
             pop_saveset(tmp, 'filename', fname, 'filepath', folder, 'savemode', 'twofiles');
             fprintf('  Converted %d/%d: %s\n', i, nFiles, fname);
             stats.converted = stats.converted + 1;

--- a/pop_functions/pop_import_ia_columns.m
+++ b/pop_functions/pop_import_ia_columns.m
@@ -335,6 +335,7 @@ function [EEG, com] = pop_import_ia_columns(EEG)
         modifiedCount = 0;
         shownImportDialog = false;
         hasImportErrors = false;
+        firstModifiedIdx = [];
 
         for i = 1:length(localALLEEG)
             if isfield(localALLEEG(i), 'eyesort_processed') && localALLEEG(i).eyesort_processed
@@ -342,6 +343,9 @@ function [EEG, com] = pop_import_ia_columns(EEG)
                     localALLEEG(i) = import_ia_columns(localALLEEG(i), filePath, condColName, itemColName, selectedCols, 'none');
                     localALLEEG(i) = eeg_checkset(localALLEEG(i), 'eventconsistency');
                     modifiedCount = modifiedCount + 1;
+                    if isempty(firstModifiedIdx)
+                        firstModifiedIdx = i;
+                    end
                     % Show diagnostic dialog for the first affected dataset;
                     % always track error severity regardless of dialog state.
                     if isfield(localALLEEG(i), 'eyesort_import_diagnostics')
@@ -371,9 +375,12 @@ function [EEG, com] = pop_import_ia_columns(EEG)
             end
         end
 
-        % Update base workspace
+        % Update base workspace with the first updated dataset for inspection
         assignin('base', 'ALLEEG', localALLEEG);
-        assignin('base', 'EEG', localALLEEG(end));
+        if ~isempty(firstModifiedIdx)
+            assignin('base', 'EEG', localALLEEG(firstModifiedIdx));
+            assignin('base', 'CURRENTSET', firstModifiedIdx);
+        end
         try
             eeglab('redraw');
         catch
@@ -399,14 +406,15 @@ function [EEG, com] = pop_import_ia_columns(EEG)
     end
 
     function importBatch(filePath, condColName, itemColName, selectedCols, bPaths, bNames)
-        h = waitbar(0, 'Importing columns into batch datasets...', 'Name', 'EyeSort - Import');
+        h = eyesort_waitbar(0, 'Importing columns into batch datasets...', 'Name', 'EyeSort - Import');
         successCount = 0;
         shownImportDialog = false;
         hasImportErrors = false;
+        firstImportedPath = '';
 
         for i = 1:length(bPaths)
-            waitbar(i / length(bPaths), h, sprintf('Processing %d of %d: %s', ...
-                i, length(bPaths), strrep(bNames{i}, '_', ' ')));
+            eyesort_waitbar(i / length(bPaths), h, sprintf('Processing %d of %d: %s', ...
+                i, length(bPaths), bNames{i}));
 
             if ~exist(bPaths{i}, 'file')
                 warning('EYESORT:FileNotFound', 'File not found, skipping: %s', bPaths{i});
@@ -443,6 +451,9 @@ function [EEG, com] = pop_import_ia_columns(EEG)
                 % Save back to the same path
                 pop_saveset(batchEEG, 'filename', bPaths{i}, 'savemode', 'twofiles');
                 successCount = successCount + 1;
+                if isempty(firstImportedPath)
+                    firstImportedPath = bPaths{i};
+                end
 
                 clear batchEEG;
             catch ME
@@ -458,6 +469,22 @@ function [EEG, com] = pop_import_ia_columns(EEG)
         end
 
         delete(h);
+
+        % Reload the first updated dataset so EEGLAB reflects the import
+        if successCount > 0 && ~isempty(firstImportedPath)
+            try
+                firstEEG = pop_loadset('filename', firstImportedPath);
+                firstEEG = eeg_checkset(firstEEG);
+                if ~isfield(firstEEG, 'saved')
+                    firstEEG.saved = 'yes';
+                end
+                assignin('base', 'EEG', firstEEG);
+                fprintf('Loaded first imported dataset for inspection: %s\n', firstEEG.filename);
+            catch ME
+                warning('EYESORT:LoadError', 'Could not load first imported dataset: %s', ME.message);
+            end
+        end
+
         if successCount > 0
             update_eyesort_session_state('importFilePath', filePath, ...
                 'importCondColName', condColName, 'importItemColName', itemColName, ...

--- a/pop_functions/pop_label_datasets.m
+++ b/pop_functions/pop_label_datasets.m
@@ -795,7 +795,7 @@ function [EEG, com] = pop_label_datasets(EEG)
             startLabelCount = EEG.eyesort_label_count;
         end
         
-        h = waitbar(0, 'Applying labels...', 'Name', 'Eye-Tracking Event Labeling');
+        h = eyesort_waitbar(0, 'Applying labels...', 'Name', 'Eye-Tracking Event Labeling');
         try
             for qi = 1:nLabels
                 currentLabelNum = startLabelCount + qi;
@@ -803,7 +803,7 @@ function [EEG, com] = pop_label_datasets(EEG)
                 if isfield(pending_labels{qi}, 'labelDescription')
                     desc = pending_labels{qi}.labelDescription;
                 end
-                waitbar(qi / nLabels, h, sprintf('Applying label %d of %d: %s', qi, nLabels, desc));
+                eyesort_waitbar(qi / nLabels, h, sprintf('Applying label %d of %d: %s', qi, nLabels, desc));
                 label_params = convert_config_to_params_gui(pending_labels{qi});
                 if ~isempty(saved_conflict_resolution)
                     label_params = [label_params, {'conflictResolution', saved_conflict_resolution}];
@@ -992,13 +992,14 @@ function [EEG, com] = pop_label_datasets(EEG)
         % all labels and all datasets so the conflict dialog never repeats.
         all_rows = {};
         processed_count = 0;
+        first_processed_path = '';
 
-        h = waitbar(0, 'Batch labeling...', 'Name', 'Batch Processing');
+        h = eyesort_waitbar(0, 'Batch labeling...', 'Name', 'Batch Processing');
         try
             for i = 1:length(batchFilePaths)
-                waitbar((i-1)/length(batchFilePaths), h, ...
+                eyesort_waitbar((i-1)/length(batchFilePaths), h, ...
                     sprintf('Processing %d of %d: %s', i, length(batchFilePaths), ...
-                    strrep(batchFilenames{i}, '_', ' ')));
+                    batchFilenames{i}));
 
                 try
                     % Compute clean filename once per dataset
@@ -1066,6 +1067,10 @@ function [EEG, com] = pop_label_datasets(EEG)
                     pop_saveset(tempEEG, 'filename', output_path, 'savemode', 'twofiles');
                     clear tempEEG;
 
+                    if isempty(first_processed_path)
+                        first_processed_path = output_path;
+                    end
+
                     processed_count = processed_count + 1;
                     fprintf('Processed %d/%d: %s\n', processed_count, length(batchFilePaths), cleanFileName);
 
@@ -1109,6 +1114,22 @@ function [EEG, com] = pop_label_datasets(EEG)
         % Clean up and close
         cleanup_temp_files(batchFilePaths);
         evalin('base', 'clear eyesort_batch_file_paths eyesort_batch_filenames eyesort_batch_mode');
+
+        % Reload the first processed dataset so EEGLAB shows labeled output
+        % instead of the leftover _textia_temp.set from Text IA processing.
+        if processed_count > 0 && ~isempty(first_processed_path)
+            try
+                EEG = pop_loadset('filename', first_processed_path);
+                EEG = eeg_checkset(EEG);
+                if ~isfield(EEG, 'saved')
+                    EEG.saved = 'yes';
+                end
+                assignin('base', 'EEG', EEG);
+                fprintf('Loaded first processed dataset for inspection: %s\n', EEG.filename);
+            catch ME
+                warning('EYESORT:LoadError', 'Could not load first processed dataset: %s', ME.message);
+            end
+        end
 
         com = sprintf('EEG = pop_label_datasets(EEG); %% Batch labeling completed with %d labels applied', current_batch_label_count);
 

--- a/pop_functions/pop_load_text_ia.m
+++ b/pop_functions/pop_load_text_ia.m
@@ -729,8 +729,17 @@ function [EEG, com] = pop_load_text_ia(EEG)
 
         % Validate trigger inputs against the loaded dataset before processing.
         % This catches format/key mismatches close to the user input fields.
-        [triggerDiagnostics, ~] = validate_triggers(EEG, startCodeStr, endCodeStr, ...
-            condTriggers, itemTriggers, sentenceStartCodeStr, sentenceEndCodeStr);
+        validationWaitbar = [];
+        try
+            validationWaitbar = eyesort_waitbar(0, 'Validating trigger inputs...', 'Name', 'EyeSort Step 2 Validation');
+            drawnow;
+            [triggerDiagnostics, ~] = validate_triggers(EEG, startCodeStr, endCodeStr, ...
+                condTriggers, itemTriggers, sentenceStartCodeStr, sentenceEndCodeStr);
+        catch validationError
+            close_validation_waitbar(validationWaitbar);
+            rethrow(validationError);
+        end
+        close_validation_waitbar(validationWaitbar);
         hasTriggerErrors = report_diagnostics(triggerDiagnostics, ...
             'EyeSort Step 2 Trigger Validation', 'dialog');
         if hasTriggerErrors
@@ -781,7 +790,7 @@ function [EEG, com] = pop_load_text_ia(EEG)
         try
             if batch_mode
                 % Process all datasets in batch mode (one at a time for memory efficiency)
-                h = waitbar(0, 'Processing Text IA for all datasets...', 'Name', 'Batch Text IA Processing');
+                h = eyesort_waitbar(0, 'Processing Text IA for all datasets...', 'Name', 'Batch Text IA Processing');
                 processed_count = 0;
                 failed_count = 0;
                 shownAssignmentDialog = false;
@@ -797,7 +806,7 @@ function [EEG, com] = pop_load_text_ia(EEG)
                 end
                 
                 for i = 1:length(batchFilePaths)
-                    waitbar(i/length(batchFilePaths), h, sprintf('Processing dataset %d of %d: %s', i, length(batchFilePaths), strrep(batchFilenames{i}, '_', ' ')));
+                    eyesort_waitbar(i/length(batchFilePaths), h, sprintf('Processing dataset %d of %d: %s', i, length(batchFilePaths), batchFilenames{i}));
                     
                     try
                         % Load dataset
@@ -931,9 +940,9 @@ function [EEG, com] = pop_load_text_ia(EEG)
                 
             else
                 % Single dataset processing
-                h = waitbar(0, 'Processing interest areas...', 'Name', 'Text IA Processing');
+                h = eyesort_waitbar(0, 'Processing interest areas...', 'Name', 'Text IA Processing');
                 try
-                    waitbar(0.3, h, 'Assigning fixations and saccades to interest area regions...');
+                    eyesort_waitbar(0.3, h, 'Assigning fixations and saccades to interest area regions...');
                     % Suppress duplicate CLI diagnostics — trigger pre-check dialog ran above
                     processedEEG = compute_text_based_ia(EEG, txtFilePath, offset, pxPerChar, ...
                                               numRegions, regionNames, conditionColName, ...
@@ -943,7 +952,7 @@ function [EEG, com] = pop_load_text_ia(EEG)
                                               sentenceStartCodeStr, sentenceEndCodeStr, conditionTypeColNames, ...
                                               'rtl', rtl, 'reportMode', 'none');
                     processedEEG = eeg_checkset(processedEEG, 'eventconsistency');
-                    waitbar(1, h, 'Done!');
+                    eyesort_waitbar(1, h, 'Done!');
                 catch ME
                     delete(h);
                     rethrow(ME);
@@ -1080,6 +1089,12 @@ function [EEG, com] = pop_load_text_ia(EEG)
             end
         else
             value = currentText; % Not grey or no placeholder data
+        end
+    end
+
+    function close_validation_waitbar(h)
+        if ~isempty(h) && ishandle(h)
+            close(h);
         end
     end
 end


### PR DESCRIPTION
perf(step-2-validation): speed up trigger matching and polish batch GUI feedback

- Reworked match_trigger_list to use precomputed event features and count maps instead of nested per-trigger/per-event scans
- validate_triggers reuses those features across start/end/condition/item/sentence checks
- Resolved current_word_text during trial_labeling and prefer it in label_datasets_core (with fallback to current_word index lookup)
- Added eyesort_waitbar so progress text renders correctly; wired it through labeling, Text IA, IA import, and event-code conversion
- After batch labeling/import, reload the first updated dataset into EEG so EEGLAB shows real output instead of leftover temp/unrelated sets
- Set CURRENTSET to the first modified dataset on in-memory IA import
- Show a short waitbar during Step 2 trigger validation in pop_load_text_ia